### PR TITLE
ci: use uvx for python-semantic-release instead of system install

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -155,12 +155,9 @@ jobs:
       - name: Set up Python
         uses: astral-sh/setup-uv@v7
 
-      - name: Install Python Semantic Release
-        run: uv pip install --system python-semantic-release
-
       - name: Run Semantic Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          semantic-release version
-          semantic-release publish
+          uvx python-semantic-release version
+          uvx python-semantic-release publish


### PR DESCRIPTION
The GitHub Actions runner's Python is externally managed (PEP 668), causing `uv pip install --system` to fail. Using `uvx` runs the tool in an isolated temporary environment, avoiding the issue entirely.