### PR TITLE
ci: use RELEASE_TOKEN for semantic-release to bypass branch protection

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -150,14 +150,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up Python
         uses: astral-sh/setup-uv@v7
 
       - name: Run Semantic Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           uvx python-semantic-release version
           uvx python-semantic-release publish


### PR DESCRIPTION
GITHUB_TOKEN cannot push directly to the protected main branch. Use a PAT (RELEASE_TOKEN) with admin rights to allow semantic-release to push version bumps and tags.