### PR TITLE
feat(command): add tabela command for football standings

### DIFF
--- a/bot/application/register_commands.py
+++ b/bot/application/register_commands.py
@@ -21,6 +21,7 @@ from bot.domain.commands.extract import ExtractCommand
 from bot.domain.commands.fact import FactCommand
 from bot.domain.commands.fipe import FipeCommand
 from bot.domain.commands.football_player import FootballPlayerCommand
+from bot.domain.commands.football_standings import FootballStandingsCommand
 from bot.domain.commands.football_team import FootballTeamCommand
 from bot.domain.commands.fuck import FuckCommand
 from bot.domain.commands.game import GameCommand
@@ -87,6 +88,7 @@ def _register_simple_commands(registry: CommandRegistry) -> None:
     registry.register(FactCommand())
     registry.register(FipeCommand())
     registry.register(FootballPlayerCommand())
+    registry.register(FootballStandingsCommand())
     registry.register(FootballTeamCommand())
     registry.register(GroupMentionsCommand())
     registry.register(HoroscopeCommand())

--- a/bot/data/football_zones.py
+++ b/bot/data/football_zones.py
@@ -1,0 +1,79 @@
+"""Classification zones per league — Libertadores, Europa League, relegation, etc."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ClassificationZone:
+    name: str
+    start: int
+    end: int
+    emoji: str
+
+
+LEAGUE_ZONES: dict[str, list[ClassificationZone]] = {
+    'pl': [
+        ClassificationZone('Champions League', 1, 4, '🟢'),
+        ClassificationZone('Europa League', 5, 5, '🟡'),
+        ClassificationZone('Conference League', 6, 6, '🟠'),
+        ClassificationZone('Rebaixamento', 18, 20, '🔴'),
+    ],
+    'la': [
+        ClassificationZone('Champions League', 1, 4, '🟢'),
+        ClassificationZone('Europa League', 5, 6, '🟡'),
+        ClassificationZone('Conference League', 7, 7, '🟠'),
+        ClassificationZone('Rebaixamento', 18, 20, '🔴'),
+    ],
+    'bl': [
+        ClassificationZone('Champions League', 1, 4, '🟢'),
+        ClassificationZone('Europa League', 5, 6, '🟡'),
+        ClassificationZone('Conference League', 7, 7, '🟠'),
+        ClassificationZone('Rebaixamento', 16, 18, '🔴'),
+    ],
+    'sa': [
+        ClassificationZone('Champions League', 1, 4, '🟢'),
+        ClassificationZone('Europa League', 5, 6, '🟡'),
+        ClassificationZone('Conference League', 7, 7, '🟠'),
+        ClassificationZone('Rebaixamento', 18, 20, '🔴'),
+    ],
+    'l1': [
+        ClassificationZone('Champions League', 1, 3, '🟢'),
+        ClassificationZone('Champions League Playoff', 4, 4, '🟡'),
+        ClassificationZone('Europa League', 5, 5, '🟡'),
+        ClassificationZone('Conference League', 6, 6, '🟠'),
+        ClassificationZone('Rebaixamento', 15, 18, '🔴'),
+    ],
+    'br': [
+        ClassificationZone('Libertadores', 1, 6, '🟢'),
+        ClassificationZone('Sul-Americana', 7, 12, '🟡'),
+        ClassificationZone('Rebaixamento', 17, 20, '🔴'),
+    ],
+    'ar': [
+        ClassificationZone('Libertadores', 1, 6, '🟢'),
+        ClassificationZone('Sul-Americana', 7, 12, '🟡'),
+        ClassificationZone('Rebaixamento', 25, 28, '🔴'),
+    ],
+    'uy': [
+        ClassificationZone('Libertadores', 1, 4, '🟢'),
+        ClassificationZone('Sul-Americana', 5, 8, '🟡'),
+        ClassificationZone('Rebaixamento', 13, 16, '🔴'),
+    ],
+    'ec': [
+        ClassificationZone('Libertadores', 1, 4, '🟢'),
+        ClassificationZone('Sul-Americana', 5, 8, '🟡'),
+        ClassificationZone('Rebaixamento', 14, 16, '🔴'),
+    ],
+    'co': [
+        ClassificationZone('Libertadores', 1, 4, '🟢'),
+        ClassificationZone('Sul-Americana', 5, 8, '🟡'),
+        ClassificationZone('Rebaixamento', 19, 20, '🔴'),
+    ],
+}
+
+MEDAL_EMOJIS: dict[int, str] = {
+    1: '🥇',
+    2: '🥈',
+    3: '🥉',
+}
+
+DEFAULT_ZONE_EMOJI = '⚪'

--- a/bot/domain/commands/football_standings.py
+++ b/bot/domain/commands/football_standings.py
@@ -1,0 +1,95 @@
+"""League standings table from Transfermarkt."""
+
+from bot.data.football import LEAGUE_CODES, LEAGUES, LeagueInfo
+from bot.data.football_zones import (
+    DEFAULT_ZONE_EMOJI,
+    LEAGUE_ZONES,
+    MEDAL_EMOJIS,
+    ClassificationZone,
+)
+from bot.domain.builders.reply import Reply
+from bot.domain.commands.base import (
+    Category,
+    Command,
+    CommandConfig,
+    OptionDef,
+    ParsedCommand,
+    Platform,
+)
+from bot.domain.models.command_data import CommandData
+from bot.domain.models.football import TmStandingRow
+from bot.domain.models.message import BotMessage
+from bot.domain.services.transfermarkt.service import TransfermarktService
+
+
+class FootballStandingsCommand(Command):
+    @property
+    def config(self) -> CommandConfig:
+        return CommandConfig(
+            name='tabela',
+            aliases=['table'],
+            options=[OptionDef(name='liga', values=LEAGUE_CODES)],
+            flags=['g4', 'z4'],
+            category=Category.OTHER,
+            platforms=[Platform.WHATSAPP, Platform.DISCORD],
+        )
+
+    @property
+    def menu_description(self) -> str:
+        return 'Tabela de classificacao de uma liga de futebol.'
+
+    async def execute(self, data: CommandData, parsed: ParsedCommand) -> list[BotMessage]:
+        liga_code = parsed.options.get('liga', 'br')
+        league = LEAGUES[liga_code]
+        standings = await TransfermarktService.fetch_full_standings(league)
+
+        if not standings:
+            return [Reply.to(data).text('Tabela nao encontrada. Tente novamente! ')]
+
+        zones = LEAGUE_ZONES.get(liga_code, [])
+
+        if 'g4' in parsed.flags and zones:
+            standings = [r for r in standings if r.rank <= zones[0].end]
+        elif 'z4' in parsed.flags and zones:
+            standings = [r for r in standings if r.rank >= zones[-1].start]
+
+        caption = self._format_table(standings, league, zones)
+        return [Reply.to(data).text(caption)]
+
+    @staticmethod
+    def _format_table(
+        standings: list[TmStandingRow],
+        league: LeagueInfo,
+        zones: list[ClassificationZone],
+    ) -> str:
+        lines: list[str] = [f'⚽ *{league.name}* {league.flag}']
+        first_zone = _find_zone(standings[0].rank, zones) if standings else None
+        prev_zone: ClassificationZone | None = first_zone
+        is_first = True
+
+        for row in standings:
+            zone = _find_zone(row.rank, zones)
+
+            if zone != prev_zone and not is_first:
+                if zone is not None:
+                    lines.append(f'\n── {zone.emoji} {zone.name} ──')
+                else:
+                    lines.append('')
+
+            is_first = False
+            prev_zone = zone
+            emoji = MEDAL_EMOJIS.get(row.rank) or (zone.emoji if zone else DEFAULT_ZONE_EMOJI)
+            diff = f'+{row.goal_diff}' if row.goal_diff > 0 else str(row.goal_diff)
+            goals = f'{row.goals_for}:{row.goals_against}'
+            lines.append(f'{emoji} {row.rank}. *{row.team}* — {row.points} pts')
+            stats = f'    {row.matches}J  {row.wins}V  {row.draws}E  {row.losses}D  {goals}  {diff}'
+            lines.append(stats)
+
+        return '\n'.join(lines)
+
+
+def _find_zone(rank: int, zones: list[ClassificationZone]) -> ClassificationZone | None:
+    for zone in zones:
+        if zone.start <= rank <= zone.end:
+            return zone
+    return None

--- a/bot/domain/models/football.py
+++ b/bot/domain/models/football.py
@@ -54,6 +54,20 @@ class SportsDBTeam:
 
 
 @dataclass(frozen=True)
+class TmStandingRow:
+    rank: int
+    team: str
+    matches: int
+    wins: int
+    draws: int
+    losses: int
+    goals_for: int
+    goals_against: int
+    goal_diff: int
+    points: int
+
+
+@dataclass(frozen=True)
 class StandingRow:
     rank: int
     team: str

--- a/bot/domain/services/transfermarkt/client.py
+++ b/bot/domain/services/transfermarkt/client.py
@@ -18,7 +18,7 @@ from bot.data.transfermarkt_urls import (
     POSITION_MAX_PAGES,
     SQUAD_VALUES_URL,
 )
-from bot.domain.models.football import TmClub, TmPlayer, TmSquadStats
+from bot.domain.models.football import TmClub, TmPlayer, TmSquadStats, TmStandingRow
 from bot.domain.services.transfermarkt.parser import TransfermarktParser
 from bot.infrastructure.http_client import HttpClient
 
@@ -95,6 +95,13 @@ class TransfermarktClient:
         response = await HttpClient.get(url, headers=HEADERS)
         response.raise_for_status()
         return TransfermarktParser.parse_tabelle(response.text)
+
+    @classmethod
+    async def fetch_full_standings(cls, league: LeagueInfo) -> list[TmStandingRow]:
+        url = f'{TransfermarktParser.TM_BASE}/{league.tm_slug}/tabelle/wettbewerb/{league.tm_id}'
+        response = await HttpClient.get(url, headers=HEADERS)
+        response.raise_for_status()
+        return TransfermarktParser.parse_full_tabelle(response.text)
 
     @classmethod
     async def fetch_top_clubs(cls, count: int) -> list[TmClub]:

--- a/bot/domain/services/transfermarkt/parser.py
+++ b/bot/domain/services/transfermarkt/parser.py
@@ -1,9 +1,15 @@
 """HTML parsing for Transfermarkt pages — public facade."""
 
+import structlog
 from bs4 import BeautifulSoup, Tag
 
-from bot.domain.models.football import TmClub, TmPlayer, TmSquadStats
+from bot.domain.models.football import TmClub, TmPlayer, TmSquadStats, TmStandingRow
 from bot.domain.services.transfermarkt.row_parser import RowParser
+
+logger = structlog.get_logger()
+
+_GOALS_SEPARATOR = ':'
+_MIN_STANDING_CELLS = 7
 
 
 class TransfermarktParser(RowParser):
@@ -76,6 +82,84 @@ class TransfermarktParser(RowParser):
             if club_id and club_id not in result:
                 result[club_id] = rank
         return result
+
+    @classmethod
+    def parse_full_tabelle(cls, html: str) -> list[TmStandingRow]:
+        soup = BeautifulSoup(html, 'html.parser')
+        table = soup.find('table', class_='items')
+        if not table or not isinstance(table, Tag):
+            return []
+        tbody = table.find('tbody')
+        rows = tbody.find_all('tr') if isinstance(tbody, Tag) else table.find_all('tr')
+        result: list[TmStandingRow] = []
+        for row in rows:
+            if not isinstance(row, Tag):
+                continue
+            standing = cls._parse_standing_row(row)
+            if standing:
+                result.append(standing)
+        return result
+
+    @classmethod
+    def _parse_standing_row(cls, row: Tag) -> TmStandingRow | None:
+        tds = row.find_all('td')
+        if not tds:
+            return None
+        rank_text = tds[0].get_text(strip=True).split()[0] if tds[0] else ''
+        try:
+            rank = int(rank_text)
+        except ValueError:
+            return None
+
+        team = cls._extract_standing_team_name(row)
+        if not team:
+            return None
+
+        cells = [
+            td.get_text(strip=True)
+            for td in row.find_all('td', class_='zentriert')
+            if isinstance(td, Tag) and 'no-border-rechts' not in (td.get('class') or [])
+        ]
+        if len(cells) < _MIN_STANDING_CELLS:
+            logger.warning('standing_row_too_few_cells', team=team, cells=len(cells))
+            return None
+
+        try:
+            matches = int(cells[0])
+            wins, draws, losses = int(cells[1]), int(cells[2]), int(cells[3])
+            goals_for, goals_against = cls._parse_goals(cells[4])
+            goal_diff = int(cells[5])
+            points = int(cells[6])
+        except (ValueError, IndexError):
+            logger.warning('standing_row_parse_error', team=team)
+            return None
+
+        return TmStandingRow(
+            rank=rank,
+            team=team,
+            matches=matches,
+            wins=wins,
+            draws=draws,
+            losses=losses,
+            goals_for=goals_for,
+            goals_against=goals_against,
+            goal_diff=goal_diff,
+            points=points,
+        )
+
+    @staticmethod
+    def _parse_goals(text: str) -> tuple[int, int]:
+        parts = text.split(_GOALS_SEPARATOR)
+        return int(parts[0]), int(parts[1])
+
+    @staticmethod
+    def _extract_standing_team_name(row: Tag) -> str:
+        td = row.find('td', class_='no-border-links')
+        if td and isinstance(td, Tag):
+            link = td.find('a')
+            if link and isinstance(link, Tag):
+                return link.get_text(strip=True)
+        return ''
 
     @classmethod
     def parse_clubs_page(cls, html: str) -> list[TmClub]:

--- a/tests/fixtures/html/full_standings.html
+++ b/tests/fixtures/html/full_standings.html
@@ -1,0 +1,85 @@
+<table class="items">
+  <thead>
+    <tr>
+      <th class="rechts">#</th>
+      <th colspan="2">Clube</th>
+      <th class="zentriert">J</th>
+      <th class="zentriert">V</th>
+      <th class="zentriert">E</th>
+      <th class="zentriert">D</th>
+      <th class="zentriert">Gols</th>
+      <th class="zentriert">SG</th>
+      <th class="zentriert">Pts</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="rechts hauptlink" style="background-color: #afd179">1</td>
+      <td class="zentriert no-border-rechts">
+        <a href="/palmeiras/spielplan/verein/1023/saison_id/2025" title="SE Palmeiras">
+          <img class="tiny_wappen" src="https://tmssl.akamaized.net//images/wappen/tiny/1023.png" title="SE Palmeiras"/>
+        </a>
+      </td>
+      <td class="no-border-links hauptlink">
+        <a href="/palmeiras/spielplan/verein/1023/saison_id/2025" title="SE Palmeiras">Palmeiras</a>
+      </td>
+      <td class="zentriert">11</td>
+      <td class="zentriert">8</td>
+      <td class="zentriert">2</td>
+      <td class="zentriert">1</td>
+      <td class="zentriert">21:10</td>
+      <td class="zentriert">11</td>
+      <td class="zentriert">26</td>
+    </tr>
+    <tr>
+      <td class="rechts hauptlink" style="background-color: #c3dc3a">2</td>
+      <td class="zentriert no-border-rechts">
+        <a href="/flamengo/spielplan/verein/614/saison_id/2025" title="CR Flamengo">
+          <img class="tiny_wappen" src="https://tmssl.akamaized.net//images/wappen/tiny/614.png" title="CR Flamengo"/>
+        </a>
+      </td>
+      <td class="no-border-links hauptlink">
+        <a href="/flamengo/spielplan/verein/614/saison_id/2025" title="CR Flamengo">Flamengo</a>
+      </td>
+      <td class="zentriert">10</td>
+      <td class="zentriert">6</td>
+      <td class="zentriert">2</td>
+      <td class="zentriert">2</td>
+      <td class="zentriert">18:10</td>
+      <td class="zentriert">8</td>
+      <td class="zentriert">20</td>
+    </tr>
+    <tr>
+      <td class="rechts hauptlink" style="background-color: #ff6347">3</td>
+      <td class="zentriert no-border-rechts">
+        <a href="/cuiaba/spielplan/verein/28022/saison_id/2025" title="Cuiaba EC">
+          <img class="tiny_wappen" src="https://tmssl.akamaized.net//images/wappen/tiny/28022.png" title="Cuiaba EC"/>
+        </a>
+      </td>
+      <td class="no-border-links hauptlink">
+        <a href="/cuiaba/spielplan/verein/28022/saison_id/2025" title="Cuiaba EC">Cuiaba</a>
+      </td>
+      <td class="zentriert">11</td>
+      <td class="zentriert">2</td>
+      <td class="zentriert">3</td>
+      <td class="zentriert">6</td>
+      <td class="zentriert">8:15</td>
+      <td class="zentriert">-7</td>
+      <td class="zentriert">9</td>
+    </tr>
+    <tr>
+      <td class="rechts hauptlink">invalid</td>
+      <td class="zentriert no-border-rechts"></td>
+      <td class="no-border-links hauptlink">
+        <a href="/bad/spielplan/verein/999/saison_id/2025" title="Bad Club">Bad Club</a>
+      </td>
+      <td class="zentriert">0</td>
+      <td class="zentriert">0</td>
+      <td class="zentriert">0</td>
+      <td class="zentriert">0</td>
+      <td class="zentriert">0:0</td>
+      <td class="zentriert">0</td>
+      <td class="zentriert">0</td>
+    </tr>
+  </tbody>
+</table>

--- a/tests/unit/commands/test_football_standings.py
+++ b/tests/unit/commands/test_football_standings.py
@@ -1,0 +1,272 @@
+import pytest
+
+from bot.data.football import LEAGUES
+from bot.data.football_zones import LEAGUE_ZONES
+from bot.domain.commands.football_standings import FootballStandingsCommand
+from bot.domain.models.football import TmStandingRow
+from bot.domain.models.message import TextContent
+from bot.domain.services.transfermarkt.service import TransfermarktService
+from tests.factories.command_data import GroupCommandDataFactory
+
+_LEAGUE = LEAGUES['br']
+_ZONES = LEAGUE_ZONES['br']
+
+
+def _make_standing(
+    rank: int,
+    team: str,
+    points: int,
+    goal_diff: int = 0,
+) -> TmStandingRow:
+    return TmStandingRow(
+        rank=rank,
+        team=team,
+        matches=10,
+        wins=6,
+        draws=2,
+        losses=2,
+        goals_for=18,
+        goals_against=10,
+        goal_diff=goal_diff,
+        points=points,
+    )
+
+
+_MOCK_STANDINGS = [
+    _make_standing(1, 'Palmeiras', 26, goal_diff=11),
+    _make_standing(2, 'Flamengo', 20, goal_diff=8),
+    _make_standing(3, 'Sao Paulo', 20, goal_diff=6),
+    _make_standing(4, 'Fluminense', 20, goal_diff=5),
+    _make_standing(5, 'Bahia', 20, goal_diff=5),
+    _make_standing(6, 'Botafogo', 18, goal_diff=3),
+    _make_standing(7, 'Fortaleza', 17, goal_diff=2),
+    _make_standing(8, 'Internacional', 16, goal_diff=1),
+    _make_standing(9, 'Atletico-MG', 15, goal_diff=0),
+    _make_standing(10, 'Corinthians', 14, goal_diff=-1),
+    _make_standing(11, 'Vasco', 13, goal_diff=-2),
+    _make_standing(12, 'Gremio', 12, goal_diff=-3),
+    _make_standing(13, 'Santos', 11, goal_diff=-4),
+    _make_standing(14, 'Cruzeiro', 10, goal_diff=-5),
+    _make_standing(15, 'Athletico-PR', 10, goal_diff=-5),
+    _make_standing(16, 'Juventude', 10, goal_diff=-6),
+    _make_standing(17, 'Cuiaba', 9, goal_diff=-7),
+    _make_standing(18, 'Vitoria', 8, goal_diff=-8),
+    _make_standing(19, 'Criciuma', 7, goal_diff=-9),
+    _make_standing(20, 'Atletico-GO', 6, goal_diff=-10),
+]
+
+
+@pytest.fixture
+def command():
+    return FootballStandingsCommand()
+
+
+class TestConfig:
+    def test_name(self, command):
+        assert command.config.name == 'tabela'
+
+    def test_alias(self, command):
+        assert 'table' in command.config.aliases
+
+    def test_category(self, command):
+        from bot.domain.commands.base import Category
+
+        assert command.config.category == Category.OTHER
+
+    def test_platforms(self, command):
+        from bot.domain.commands.base import Platform
+
+        assert Platform.WHATSAPP in command.config.platforms
+        assert Platform.DISCORD in command.config.platforms
+
+
+class TestDefaultLiga:
+    @pytest.mark.anyio
+    async def test_defaults_to_brasileirao(self, command, mocker):
+        mock_fetch = mocker.AsyncMock(return_value=_MOCK_STANDINGS)
+        mocker.patch.object(TransfermarktService, 'fetch_full_standings', new=mock_fetch)
+
+        data = GroupCommandDataFactory.build(text=',tabela')
+        messages = await command.run(data)
+
+        mock_fetch.assert_called_once_with(_LEAGUE)
+        assert isinstance(messages[0].content, TextContent)
+
+
+class TestFullTable:
+    @pytest.mark.anyio
+    async def test_returns_all_teams(self, command, mocker):
+        mocker.patch.object(
+            TransfermarktService,
+            'fetch_full_standings',
+            new=mocker.AsyncMock(return_value=_MOCK_STANDINGS),
+        )
+
+        data = GroupCommandDataFactory.build(text=',tabela br')
+        messages = await command.run(data)
+
+        text = messages[0].content.text
+        assert 'Palmeiras' in text
+        assert 'Atletico-GO' in text
+
+    @pytest.mark.anyio
+    async def test_contains_league_name(self, command, mocker):
+        mocker.patch.object(
+            TransfermarktService,
+            'fetch_full_standings',
+            new=mocker.AsyncMock(return_value=_MOCK_STANDINGS),
+        )
+
+        data = GroupCommandDataFactory.build(text=',tabela br')
+        messages = await command.run(data)
+
+        assert _LEAGUE.name in messages[0].content.text
+
+    @pytest.mark.anyio
+    async def test_contains_points(self, command, mocker):
+        mocker.patch.object(
+            TransfermarktService,
+            'fetch_full_standings',
+            new=mocker.AsyncMock(return_value=_MOCK_STANDINGS),
+        )
+
+        data = GroupCommandDataFactory.build(text=',tabela br')
+        messages = await command.run(data)
+
+        assert '26 pts' in messages[0].content.text
+
+    @pytest.mark.anyio
+    async def test_shows_medal_emojis_for_top3(self, command, mocker):
+        mocker.patch.object(
+            TransfermarktService,
+            'fetch_full_standings',
+            new=mocker.AsyncMock(return_value=_MOCK_STANDINGS),
+        )
+
+        data = GroupCommandDataFactory.build(text=',tabela br')
+        messages = await command.run(data)
+
+        text = messages[0].content.text
+        assert '🥇' in text
+        assert '🥈' in text
+        assert '🥉' in text
+
+    @pytest.mark.anyio
+    async def test_shows_zone_separators(self, command, mocker):
+        mocker.patch.object(
+            TransfermarktService,
+            'fetch_full_standings',
+            new=mocker.AsyncMock(return_value=_MOCK_STANDINGS),
+        )
+
+        data = GroupCommandDataFactory.build(text=',tabela br')
+        messages = await command.run(data)
+
+        text = messages[0].content.text
+        assert 'Sul-Americana' in text
+        assert 'Rebaixamento' in text
+
+
+class TestG4Flag:
+    @pytest.mark.anyio
+    async def test_filters_top_zone(self, command, mocker):
+        mocker.patch.object(
+            TransfermarktService,
+            'fetch_full_standings',
+            new=mocker.AsyncMock(return_value=_MOCK_STANDINGS),
+        )
+
+        data = GroupCommandDataFactory.build(text=',tabela br g4')
+        messages = await command.run(data)
+
+        text = messages[0].content.text
+        assert 'Palmeiras' in text
+        assert 'Botafogo' in text
+        assert 'Fortaleza' not in text
+        assert 'Atletico-GO' not in text
+
+
+class TestZ4Flag:
+    @pytest.mark.anyio
+    async def test_filters_bottom_zone(self, command, mocker):
+        mocker.patch.object(
+            TransfermarktService,
+            'fetch_full_standings',
+            new=mocker.AsyncMock(return_value=_MOCK_STANDINGS),
+        )
+
+        data = GroupCommandDataFactory.build(text=',tabela br z4')
+        messages = await command.run(data)
+
+        text = messages[0].content.text
+        assert 'Cuiaba' in text
+        assert 'Atletico-GO' in text
+        assert 'Palmeiras' not in text
+
+
+class TestEmptyStandings:
+    @pytest.mark.anyio
+    async def test_returns_error(self, command, mocker):
+        mocker.patch.object(
+            TransfermarktService,
+            'fetch_full_standings',
+            new=mocker.AsyncMock(return_value=[]),
+        )
+
+        data = GroupCommandDataFactory.build(text=',tabela br')
+        messages = await command.run(data)
+
+        assert isinstance(messages[0].content, TextContent)
+
+
+class TestFormatGoalDiff:
+    def test_positive_goal_diff(self, command):
+        standings = [_make_standing(1, 'Team', 20, goal_diff=5)]
+
+        result = command._format_table(standings, _LEAGUE, _ZONES)
+
+        assert '+5' in result
+
+    def test_negative_goal_diff(self, command):
+        standings = [_make_standing(1, 'Team', 20, goal_diff=-3)]
+
+        result = command._format_table(standings, _LEAGUE, _ZONES)
+
+        assert '-3' in result
+
+    def test_zero_goal_diff(self, command):
+        standings = [_make_standing(1, 'Team', 20, goal_diff=0)]
+
+        result = command._format_table(standings, _LEAGUE, _ZONES)
+
+        assert '  0' in result
+
+
+class TestZoneEmojis:
+    def test_libertadores_zone_gets_green(self, command):
+        standings = [_make_standing(4, 'Team', 20)]
+
+        result = command._format_table(standings, _LEAGUE, _ZONES)
+
+        assert '🟢' in result
+
+    def test_sulamericana_zone_gets_yellow(self, command):
+        standings = [_make_standing(8, 'Team', 15)]
+
+        result = command._format_table(standings, _LEAGUE, _ZONES)
+
+        assert '🟡' in result
+
+    def test_relegation_zone_gets_red(self, command):
+        standings = [_make_standing(18, 'Team', 8)]
+
+        result = command._format_table(standings, _LEAGUE, _ZONES)
+
+        assert '🔴' in result
+
+    def test_mid_table_gets_default(self, command):
+        standings = [_make_standing(14, 'Team', 10)]
+
+        result = command._format_table(standings, _LEAGUE, _ZONES)
+
+        assert '⚪' in result

--- a/tests/unit/services/test_transfermarkt.py
+++ b/tests/unit/services/test_transfermarkt.py
@@ -134,6 +134,44 @@ class TestParseTabelle:
         assert TransfermarktParser.parse_tabelle('<div>no table</div>') == {}
 
 
+@pytest.fixture
+def full_standings_html() -> str:
+    return _load_html('full_standings.html')
+
+
+class TestParseFullTabelle:
+    def test_returns_full_standing_rows(self, full_standings_html):
+        result = TransfermarktParser.parse_full_tabelle(full_standings_html)
+
+        assert len(result) == 3
+        first = result[0]
+        assert first.rank == 1
+        assert first.team == 'Palmeiras'
+        assert first.matches == 11
+        assert first.wins == 8
+        assert first.draws == 2
+        assert first.losses == 1
+        assert first.goals_for == 21
+        assert first.goals_against == 10
+        assert first.goal_diff == 11
+        assert first.points == 26
+
+    def test_parses_negative_goal_difference(self, full_standings_html):
+        result = TransfermarktParser.parse_full_tabelle(full_standings_html)
+
+        cuiaba = result[2]
+        assert cuiaba.goal_diff == -7
+
+    def test_skips_rows_with_non_numeric_rank(self, full_standings_html):
+        result = TransfermarktParser.parse_full_tabelle(full_standings_html)
+
+        teams = [r.team for r in result]
+        assert 'Bad Club' not in teams
+
+    def test_empty_html_returns_empty_list(self):
+        assert TransfermarktParser.parse_full_tabelle('<div>no table</div>') == []
+
+
 class TestParseClubsPage:
     def test_returns_clubs_in_rank_order(self, clubs_page_html):
         clubs = TransfermarktParser.parse_clubs_page(clubs_page_html)


### PR DESCRIPTION
## Summary
- Add new `tabela` command that displays football league standings table from Transfermarkt
- Supports filtering by `--g4` and `--z4` flags to show only G4 or Z4 zones
- League codes supported via `,tabela br` (default), `,tabela eng`, `,tabela es`, etc.
- New command file with formatting logic that groups teams by zones (e.g., Libertadores, Sul-Americana, Rebaixados)
- New `TmStandingRow` dataclass model for standing data
- New Transfermarkt parser for full standings table (`parse_full_tabelle`)
- Tests included for command and parser