### PR TITLE
feat(menu): add INFORMATION category for score/table/info commands

### DIFF
--- a/bot/data/menu_messages.py
+++ b/bot/data/menu_messages.py
@@ -69,10 +69,11 @@ CATEGORY_HEADERS: dict[str, str] = {
     'group': '🫂 FUNÇÕES DE GRUPO 🫂',
     'random': '🎲 FUNÇÕES ALEATÓRIAS 🎲',
     'download': '💾 FUNÇÕES DE DOWNLOAD 💾',
+    'info': '📰 INFORMAÇÕES 📰',
     'other': '🙂 OUTRAS FUNÇÕES 🙂',
 }
 
-CATEGORY_ORDER: list[str] = ['group', 'random', 'download', 'other']
+CATEGORY_ORDER: list[str] = ['group', 'random', 'download', 'info', 'other']
 
 ALEATORIA_SUBHEADER = (
     '\n\n_(use as opções *show* e/ou *dm* para enviar imagens'

--- a/bot/domain/commands/base.py
+++ b/bot/domain/commands/base.py
@@ -29,6 +29,7 @@ class Category(StrEnum):
     RANDOM = 'random'
     DOWNLOAD = 'download'
     GROUP = 'group'
+    INFORMATION = 'info'
     OTHER = 'other'
 
 

--- a/bot/domain/commands/currency.py
+++ b/bot/domain/commands/currency.py
@@ -23,7 +23,7 @@ class CurrencyCommand(Command):
             aliases=['currency'],
             args=ArgType.OPTIONAL,
             args_label='valor',
-            category=Category.OTHER,
+            category=Category.INFORMATION,
             platforms=[Platform.WHATSAPP, Platform.DISCORD],
         )
 

--- a/bot/domain/commands/football_standings.py
+++ b/bot/domain/commands/football_standings.py
@@ -30,13 +30,13 @@ class FootballStandingsCommand(Command):
             aliases=['table'],
             options=[OptionDef(name='liga', values=LEAGUE_CODES)],
             flags=['g4', 'z4'],
-            category=Category.OTHER,
+            category=Category.INFORMATION,
             platforms=[Platform.WHATSAPP, Platform.DISCORD],
         )
 
     @property
     def menu_description(self) -> str:
-        return 'Tabela de classificacao de uma liga de futebol.'
+        return 'Tabela de classificação de uma liga de futebol com pontos, V/E/D e outros stats.'
 
     async def execute(self, data: CommandData, parsed: ParsedCommand) -> list[BotMessage]:
         liga_code = parsed.options.get('liga', 'br')

--- a/bot/domain/commands/lottery.py
+++ b/bot/domain/commands/lottery.py
@@ -39,7 +39,7 @@ class LotteryCommand(Command):
             args_pattern=r'^(?:ppt|ptm|pt|ptv|ptn|cor)?$',
             args_label='sorteio',
             options=[OptionDef(name='regiao', values=['rio', 'sp', 'mg', 'ba', 'go', 'ce'])],
-            category=Category.OTHER,
+            category=Category.INFORMATION,
             platforms=[Platform.WHATSAPP, Platform.DISCORD],
         )
 

--- a/bot/domain/commands/moon.py
+++ b/bot/domain/commands/moon.py
@@ -19,7 +19,7 @@ class MoonCommand(Command):
         return CommandConfig(
             name='lua',
             aliases=['moon'],
-            category=Category.OTHER,
+            category=Category.INFORMATION,
             platforms=[Platform.WHATSAPP, Platform.DISCORD],
         )
 

--- a/bot/domain/commands/score.py
+++ b/bot/domain/commands/score.py
@@ -48,13 +48,13 @@ class ScoreCommand(Command):
             name='placar',
             aliases=['score'],
             flags=['past', 'now', 'next'],
-            category=Category.OTHER,
+            category=Category.INFORMATION,
             platforms=[Platform.WHATSAPP, Platform.DISCORD],
         )
 
     @property
     def menu_description(self) -> str:
-        return 'Jogos de futebol ao vivo.'
+        return 'Placar ao vivo de jogos de futebol com resultados ao vivo, próximos e encerrados.'
 
     async def execute(self, data: CommandData, parsed: ParsedCommand) -> list[BotMessage]:
         matches = await TransfermarktService.fetch_live_matches()

--- a/tests/unit/commands/test_football_standings.py
+++ b/tests/unit/commands/test_football_standings.py
@@ -71,7 +71,7 @@ class TestConfig:
     def test_category(self, command):
         from bot.domain.commands.base import Category
 
-        assert command.config.category == Category.OTHER
+        assert command.config.category == Category.INFORMATION
 
     def test_platforms(self, command):
         from bot.domain.commands.base import Platform

--- a/tests/unit/commands/test_menu.py
+++ b/tests/unit/commands/test_menu.py
@@ -220,3 +220,42 @@ class TestPrivateChat:
 
         # MenuCommand has no group_only restriction
         assert len(messages) == 1
+
+
+class TestCategoryEnum:
+    def test_all_categories_have_headers(self):
+        from bot.data.menu_messages import CATEGORY_HEADERS
+        from bot.domain.commands.base import Category
+
+        for cat in Category:
+            assert cat.value in CATEGORY_HEADERS, f'Category.{cat.name} missing in CATEGORY_HEADERS'
+
+    def test_all_categories_in_order(self):
+        from bot.data.menu_messages import CATEGORY_ORDER
+        from bot.domain.commands.base import Category
+
+        for cat in Category:
+            assert cat.value in CATEGORY_ORDER, f'Category.{cat.name} missing in CATEGORY_ORDER'
+
+    def test_info_category_header_defined(self):
+        from bot.data.menu_messages import CATEGORY_HEADERS
+
+        assert 'info' in CATEGORY_HEADERS
+        assert 'INFORMA' in CATEGORY_HEADERS['info']
+
+    def test_info_category_in_order(self):
+        from bot.data.menu_messages import CATEGORY_ORDER
+
+        assert 'info' in CATEGORY_ORDER
+
+    def test_info_commands_have_correct_category(self):
+        from bot.domain.commands.base import Category
+        from bot.domain.commands.football_standings import FootballStandingsCommand
+        from bot.domain.commands.lottery import LotteryCommand
+        from bot.domain.commands.moon import MoonCommand
+        from bot.domain.commands.score import ScoreCommand
+
+        assert ScoreCommand().config.category == Category.INFORMATION
+        assert FootballStandingsCommand().config.category == Category.INFORMATION
+        assert MoonCommand().config.category == Category.INFORMATION
+        assert LotteryCommand().config.category == Category.INFORMATION

--- a/tests/unit/commands/test_score.py
+++ b/tests/unit/commands/test_score.py
@@ -135,7 +135,7 @@ class TestConfig:
     def test_category(self, command):
         from bot.domain.commands.base import Category
 
-        assert command.config.category == Category.OTHER
+        assert command.config.category == Category.INFORMATION
 
     def test_platforms(self, command):
         from bot.domain.commands.base import Platform
@@ -146,7 +146,9 @@ class TestConfig:
 
 class TestMenuDescription:
     def test_description(self, command):
-        assert command.menu_description == 'Jogos de futebol ao vivo.'
+        desc = 'Placar ao vivo de jogos de futebol com resultados ao vivo, '
+        desc += 'próximos e encerrados.'
+        assert command.menu_description == desc
 
 
 class TestExecute:


### PR DESCRIPTION
## Summary

- Add new `Category.INFORMATION` ('info') enum for informational commands like scores, standings, moon, lottery
- Move `placar`, `tabela`, `lua`, `bicho` to INFORMATION category  
- Add new menu section header "📰 INFORMAÇÕES 📰" between DOWNLOAD and OTHER
- Update menu descriptions for `placar` and `tabela` with more detail
- Add regression tests (`TestCategoryEnum`) to ensure all categories have headers and are in CATEGORY_ORDER

## Changes

| File | Change |
|------|--------|
| `bot/domain/commands/base.py` | Add `INFORMATION = 'info'` to Category enum |
| `bot/data/menu_messages.py` | Add 'info' header and include in CATEGORY_ORDER |
| `bot/domain/commands/score.py` | Move to INFORMATION, update description |
| `bot/domain/commands/football_standings.py` | Move to INFORMATION, update description |
| `bot/domain/commands/moon.py` | Move to INFORMATION |
| `bot/domain/commands/lottery.py` | Move to INFORMATION |
| `tests/unit/commands/test_menu.py` | Add TestCategoryEnum regression tests |
| `tests/unit/commands/test_score.py` | Update tests for new category/description |
| `tests/unit/commands/test_football_standings.py` | Update test for new category |

## Menu Structure

- 🫂 GRUPO
- 🎲 ALEATÓRIAS
- 💾 DOWNLOAD
- 📰 **INFORMAÇÕES** (new!)
- 🙂 OUTRAS FUNÇÕES