### PR TITLE
fix(deploy): align bot image ref with pipeline push tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   bot:
     container_name: bot
-    image: ghcr.io/sandrosmarzaro/resenhazord2-python:latest
+    image: ghcr.io/sandrosmarzaro/resenhazord2:python
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- `docker-compose.yml` pulled the Python bot from `ghcr.io/sandrosmarzaro/resenhazord2-python:latest` (a legacy/unused repo), but the pipeline publishes to `ghcr.io/sandrosmarzaro/resenhazord2:python`.
- On every deploy, `docker compose pull` resolved to an unchanged (stale) image digest, so compose logged `Container bot Running` instead of `Recreated` — production kept running outdated code despite every CI pipeline being green.
- Symptom in the wild: `,placar` (1.2.0), `,tabela` (1.1.0), `,cotação` move and the whole `INFORMATION` menu section (1.3.0) never reached the VPS.

## Test plan
- [ ] Merge to `main` and watch the `deploy` job log.
- [ ] Confirm the line reads `Container bot  Recreated` (not `Running`).
- [ ] In a WhatsApp chat, send `,menu` and verify the `📰 INFORMAÇÕES 📰` section appears with `,placar`, `,tabela`, and `,cotação`.
- [ ] Smoke-test `,placar` and `,tabela br` against live Transfermarkt data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)