### PR TITLE
feat(sticker): add -X% option to reduce quality and resolution

### DIFF
--- a/bot/domain/commands/sticker.py
+++ b/bot/domain/commands/sticker.py
@@ -21,13 +21,17 @@ logger = structlog.get_logger()
 class StickerCommand(Command):
     MEDIA_TYPES = frozenset(('image', 'video', 'sticker'))
     STICKER_TYPES: ClassVar[list[str]] = ['crop', 'full', 'circle', 'rounded']
+    QUALITY_PATTERN = r'-[1-9]\d?%'
 
     @property
     def config(self) -> CommandConfig:
         return CommandConfig(
             name='stic',
             aliases=['fig', 'figurinha', 'sticker'],
-            options=[OptionDef(name='type', values=self.STICKER_TYPES)],
+            options=[
+                OptionDef(name='type', values=self.STICKER_TYPES),
+                OptionDef(name='quality', pattern=self.QUALITY_PATTERN),
+            ],
             args=ArgType.OPTIONAL,
             args_label='pack | autor',
             category=Category.DOWNLOAD,
@@ -47,6 +51,7 @@ class StickerCommand(Command):
             ]
 
         sticker_type = parsed.options.get('type', 'full')
+        quality_reduction = self._parse_quality_reduction(parsed.options.get('quality'))
         pack, author = self._parse_pack_author(parsed.rest)
         pack = pack or StickerCreator.DEFAULT_PACK
         author = author or StickerCreator.DEFAULT_AUTHOR
@@ -56,13 +61,20 @@ class StickerCommand(Command):
             jid=data.jid,
             media_type=data.media_type,
             sticker_type=sticker_type,
+            quality_reduction=quality_reduction,
             pack=pack,
             author=author,
         )
 
         buffer = await self._get_media(data)
-        sticker = await StickerCreator.create(buffer, sticker_type)
+        sticker = await StickerCreator.create(buffer, sticker_type, quality_reduction)
         return [Reply.to(data).sticker(sticker, pack=pack, author=author)]
+
+    @staticmethod
+    def _parse_quality_reduction(token: str | None) -> int:
+        if not token:
+            return 0
+        return int(token.strip('-%'))
 
     @staticmethod
     def _parse_pack_author(args: str) -> tuple[str, str]:

--- a/bot/domain/services/sticker_creator.py
+++ b/bot/domain/services/sticker_creator.py
@@ -9,6 +9,8 @@ from PIL import Image, ImageDraw, ImageOps
 class StickerCreator:
     STICKER_SIZE = (512, 512)
     WEBP_QUALITY = 50
+    MIN_WEBP_QUALITY = 1
+    MIN_WORKING_SIZE = 16
     MAX_VIDEO_DURATION = 10
     VIDEO_FPS = 15
     DEFAULT_PACK = 'Resenha'
@@ -20,13 +22,28 @@ class StickerCreator:
         cls,
         buffer: bytes,
         sticker_type: str = 'full',
+        quality_reduction: int = 0,
     ) -> bytes:
+        quality = cls._effective_quality(quality_reduction)
+        working_size = cls._effective_working_size(quality_reduction)
         if cls._is_video(buffer):
-            return await cls._create_from_video(buffer)
-        return cls._create_from_image(buffer, sticker_type)
+            return await cls._create_from_video(buffer, quality, working_size)
+        return cls._create_from_image(buffer, sticker_type, quality, working_size)
 
     @classmethod
-    def _create_from_image(cls, buffer: bytes, sticker_type: str) -> bytes:
+    def _effective_quality(cls, quality_reduction: int) -> int:
+        reduced = round(cls.WEBP_QUALITY * (100 - quality_reduction) / 100)
+        return max(cls.MIN_WEBP_QUALITY, reduced)
+
+    @classmethod
+    def _effective_working_size(cls, quality_reduction: int) -> int:
+        reduced = round(cls.STICKER_SIZE[0] * (100 - quality_reduction) / 100)
+        return max(cls.MIN_WORKING_SIZE, reduced)
+
+    @classmethod
+    def _create_from_image(
+        cls, buffer: bytes, sticker_type: str, quality: int, working_size: int
+    ) -> bytes:
         img = Image.open(io.BytesIO(buffer)).convert('RGBA')
 
         match sticker_type:
@@ -39,12 +56,20 @@ class StickerCreator:
             case _:  # full
                 img = cls._contain_on_transparent(img)
 
+        if working_size < cls.STICKER_SIZE[0]:
+            img = cls._pixelate(img, working_size)
+
         output = io.BytesIO()
-        img.save(output, format='WEBP', quality=cls.WEBP_QUALITY)
+        img.save(output, format='WEBP', quality=quality)
         return output.getvalue()
 
     @classmethod
-    async def _create_from_video(cls, buffer: bytes) -> bytes:
+    def _pixelate(cls, img: Image.Image, working_size: int) -> Image.Image:
+        small = img.resize((working_size, working_size), Image.Resampling.BILINEAR)
+        return small.resize(cls.STICKER_SIZE, Image.Resampling.NEAREST)
+
+    @classmethod
+    async def _create_from_video(cls, buffer: bytes, quality: int, working_size: int) -> bytes:
         with tempfile.TemporaryDirectory() as tmpdir:
             input_path = Path(tmpdir) / 'input'
             output_path = Path(tmpdir) / 'output.webp'
@@ -58,10 +83,14 @@ class StickerCreator:
                 'libwebp',
                 '-vf',
                 (
-                    'scale=512:512:force_original_aspect_ratio=decrease,'
+                    f'scale={working_size}:{working_size}:'
+                    'force_original_aspect_ratio=decrease:flags=bilinear,'
                     f'fps={cls.VIDEO_FPS},'
-                    'pad=512:512:-1:-1:color=0x00000000'
+                    f'pad={working_size}:{working_size}:-1:-1:color=0x00000000,'
+                    'scale=512:512:flags=neighbor'
                 ),
+                '-quality',
+                str(quality),
                 '-loop',
                 '0',
                 '-t',

--- a/tests/unit/commands/test_sticker.py
+++ b/tests/unit/commands/test_sticker.py
@@ -30,6 +30,11 @@ class TestMatches:
             (', stic Anime | Sandro', True),
             (', stic crop Anime | Sandro', True),
             (', sticker Meu Pack', True),
+            (', stic -50%', True),
+            (', stic -1%', True),
+            (', stic -99%', True),
+            (', stic crop -25%', True),
+            (', stic -50% Anime | Sandro', True),
             ('stic', False),
             ('hello', False),
         ],
@@ -83,7 +88,7 @@ class TestStickerCreation:
         assert len(messages) == 1
         assert messages[0].content.data == b'sticker-data'
         mock_whatsapp.download_media.assert_called_once_with(MESSAGE_ID, 'direct')
-        mock_create.assert_called_once_with(b'image-data', 'full')
+        mock_create.assert_called_once_with(b'image-data', 'full', 0)
 
     @pytest.mark.anyio
     async def test_creates_sticker_from_quoted_sticker(self, command, mock_whatsapp, mocker):
@@ -104,7 +109,7 @@ class TestStickerCreation:
         assert len(messages) == 1
         assert messages[0].content.data == b'new-sticker'
         mock_whatsapp.download_media.assert_called_once_with(MESSAGE_ID, 'quoted')
-        mock_create.assert_called_once_with(b'sticker-data', 'full')
+        mock_create.assert_called_once_with(b'sticker-data', 'full', 0)
 
     @pytest.mark.anyio
     async def test_creates_sticker_from_quoted_video(self, command, mock_whatsapp, mocker):
@@ -123,7 +128,7 @@ class TestStickerCreation:
         await command.run(data)
 
         mock_whatsapp.download_media.assert_called_once_with(MESSAGE_ID, 'quoted')
-        mock_create.assert_called_once_with(b'video-data', 'full')
+        mock_create.assert_called_once_with(b'video-data', 'full', 0)
 
     @pytest.mark.anyio
     async def test_sticker_type_option(self, command, mock_whatsapp, mocker):
@@ -141,7 +146,7 @@ class TestStickerCreation:
 
         await command.run(data)
 
-        mock_create.assert_called_once_with(b'image-data', 'crop')
+        mock_create.assert_called_once_with(b'image-data', 'crop', 0)
 
     @pytest.mark.anyio
     @pytest.mark.parametrize('sticker_type', ['crop', 'full', 'circle', 'rounded'])
@@ -160,7 +165,7 @@ class TestStickerCreation:
 
         await command.run(data)
 
-        mock_create.assert_called_once_with(b'data', sticker_type)
+        mock_create.assert_called_once_with(b'data', sticker_type, 0)
 
     @pytest.mark.anyio
     async def test_returns_sticker_content(self, command, mock_whatsapp, mocker):
@@ -201,7 +206,7 @@ class TestStickerCreation:
 
         assert len(messages) == 1
         mock_whatsapp.download_media.assert_not_called()
-        mock_create.assert_called_once_with(b'proactive-image', 'full')
+        mock_create.assert_called_once_with(b'proactive-image', 'full', 0)
 
 
 class TestPackAuthor:
@@ -261,6 +266,63 @@ class TestPackAuthor:
 
         assert messages[0].content.pack == 'Anime'
         assert messages[0].content.author == 'Sandro'
+
+
+class TestQualityReduction:
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ('text', 'expected'),
+        [
+            (',stic -1%', 1),
+            (',stic -50%', 50),
+            (',stic -99%', 99),
+            (',stic crop -25%', 25),
+        ],
+    )
+    async def test_quality_reduction_forwarded(
+        self, command, mock_whatsapp, mocker, text, expected
+    ):
+        mock_whatsapp.download_media.return_value = b'img'
+        data = GroupCommandDataFactory.build(
+            text=text,
+            media_type='image',
+            media_source='direct',
+            message_id=MESSAGE_ID,
+        )
+        mock_create = mocker.patch(
+            'bot.domain.commands.sticker.StickerCreator.create',
+            return_value=b'sticker',
+        )
+
+        await command.run(data)
+
+        assert mock_create.call_args.args[2] == expected
+
+    @pytest.mark.anyio
+    async def test_quality_coexists_with_pack_author(self, command, mock_whatsapp, mocker):
+        mock_whatsapp.download_media.return_value = b'img'
+        data = GroupCommandDataFactory.build(
+            text=',stic -30% Anime | Sandro',
+            media_type='image',
+            media_source='direct',
+            message_id=MESSAGE_ID,
+        )
+        mock_create = mocker.patch(
+            'bot.domain.commands.sticker.StickerCreator.create',
+            return_value=b'sticker',
+        )
+
+        messages = await command.run(data)
+
+        mock_create.assert_called_once_with(b'img', 'full', 30)
+        assert messages[0].content.pack == 'Anime'
+        assert messages[0].content.author == 'Sandro'
+
+    def test_parse_quality_none(self, command):
+        assert command._parse_quality_reduction(None) == 0
+
+    def test_parse_quality_token(self, command):
+        assert command._parse_quality_reduction('-42%') == 42
 
 
 class TestParsePackAuthor:

--- a/tests/unit/services/test_sticker_creator.py
+++ b/tests/unit/services/test_sticker_creator.py
@@ -74,6 +74,52 @@ class TestStickerCreatorImage:
         full_result = await StickerCreator.create(_create_test_image(), 'full')
         assert self._webp_to_image(default_result).size == self._webp_to_image(full_result).size
 
+    def test_pixelate_produces_block_regions(self) -> None:
+        img = Image.new('RGBA', StickerCreator.STICKER_SIZE, 'red')
+        for x in range(img.width):
+            for y in range(img.height):
+                img.putpixel((x, y), (x % 256, y % 256, 128, 255))
+
+        result = StickerCreator._pixelate(img, working_size=32)
+
+        assert result.size == StickerCreator.STICKER_SIZE
+        block = StickerCreator.STICKER_SIZE[0] // 32
+        assert result.getpixel((0, 0)) == result.getpixel((block - 1, block - 1))
+
+    @pytest.mark.anyio
+    async def test_quality_reduction_passed_to_pil(self, mocker) -> None:
+        save_spy = mocker.spy(Image.Image, 'save')
+
+        await StickerCreator.create(_create_test_image(), 'full', quality_reduction=50)
+
+        assert save_spy.call_args.kwargs['quality'] == 25
+
+    @pytest.mark.anyio
+    async def test_quality_reduction_floors_at_min(self, mocker) -> None:
+        save_spy = mocker.spy(Image.Image, 'save')
+
+        await StickerCreator.create(_create_test_image(), 'full', quality_reduction=99)
+
+        assert save_spy.call_args.kwargs['quality'] >= StickerCreator.MIN_WEBP_QUALITY
+
+    def test_effective_quality_no_reduction(self) -> None:
+        assert StickerCreator._effective_quality(0) == StickerCreator.WEBP_QUALITY
+
+    def test_effective_quality_half_reduction(self) -> None:
+        assert StickerCreator._effective_quality(50) == 25
+
+    def test_effective_quality_never_below_min(self) -> None:
+        assert StickerCreator._effective_quality(99) >= StickerCreator.MIN_WEBP_QUALITY
+
+    def test_effective_working_size_no_reduction(self) -> None:
+        assert StickerCreator._effective_working_size(0) == StickerCreator.STICKER_SIZE[0]
+
+    def test_effective_working_size_half_reduction(self) -> None:
+        assert StickerCreator._effective_working_size(50) == 256
+
+    def test_effective_working_size_never_below_min(self) -> None:
+        assert StickerCreator._effective_working_size(99) >= StickerCreator.MIN_WORKING_SIZE
+
 
 class TestStickerCreatorVideo:
     @pytest.mark.anyio
@@ -107,6 +153,37 @@ class TestStickerCreatorVideo:
         assert call_args[0] == 'ffmpeg'
         assert '-vcodec' in call_args
         assert 'libwebp' in call_args
+        assert '-quality' in call_args
+
+    @pytest.mark.anyio
+    async def test_video_quality_reduction_passed_to_ffmpeg(self, mocker) -> None:
+        img = Image.new('RGBA', (512, 512), 'red')
+        buf = io.BytesIO()
+        img.save(buf, format='WEBP')
+        webp_bytes = buf.getvalue()
+
+        mock_proc = mocker.AsyncMock()
+        mock_proc.communicate.return_value = (b'', b'')
+        mock_proc.returncode = 0
+
+        def write_fake_output(*args, **_kwargs):
+            Path(args[-1]).write_bytes(webp_bytes)
+
+        async def fake_run(*args, **_kwargs):
+            write_fake_output(*args)
+            return mock_proc
+
+        mock_run = mocker.patch(
+            'bot.domain.services.sticker_creator.asyncio.create_subprocess_exec',
+            side_effect=fake_run,
+        )
+        video_buffer = b'\x00\x00\x00\x1c' + b'ftyp' + b'isom' + b'\x00' * 100
+
+        await StickerCreator.create(video_buffer, 'full', quality_reduction=80)
+
+        call_args = mock_run.call_args[0]
+        quality_index = call_args.index('-quality')
+        assert call_args[quality_index + 1] == '10'
 
     @pytest.mark.anyio
     async def test_video_ffmpeg_error_propagates(self, mocker) -> None:


### PR DESCRIPTION
## Summary
- New `-X%` token (1-99%) on `,stic`/`,fig`/`,sticker` that pixelates the output.
- Compounds two effects: downscales the working canvas to `512 * (100-X)%` px then nearest-upscales back to 512 (blocky pixels), and reduces the WEBP encoder quality by the same factor.
- Applies to both image and video stickers (ffmpeg filter chain uses `flags=bilinear` for the downscale and `flags=neighbor` for the upscale).
- Coexists with existing `type` option and `pack | autor` args (e.g. `,stic crop -50% MyPack | MyAuthor`).

## Test plan
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pytest` — 1886 passed
- [x] Manual WhatsApp sanity check: `,stic -50%`, `,stic -95%`, `,stic crop -30% Pack | Author`
- [ ] Animated sticker: reply to a video with `,stic -80%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)