### PR TITLE
fix(sticker): preserve animated webp + apply -X% reduction per frame

### DIFF
--- a/bot/domain/services/sticker_creator.py
+++ b/bot/domain/services/sticker_creator.py
@@ -19,6 +19,8 @@ class StickerCreator:
     MIN_ANIMATED_WEBP_LEN = 21
     WEBP_ANIMATION_FLAG = 0x02
     DEFAULT_FRAME_DURATION_MS = 100
+    ANMF_DURATION_OFFSET = 12
+    ANMF_DURATION_SIZE = 3
 
     @classmethod
     async def create(
@@ -60,13 +62,13 @@ class StickerCreator:
         cls, buffer: bytes, sticker_type: str, quality: int, working_size: int
     ) -> bytes:
         src = Image.open(io.BytesIO(buffer))
+        n_frames = getattr(src, 'n_frames', 1)
+        per_frame_ms = cls._parse_webp_durations(buffer, n_frames)
+
         frames: list[Image.Image] = []
-        durations: list[int] = []
-        for index in range(getattr(src, 'n_frames', 1)):
+        for index in range(n_frames):
             src.seek(index)
-            frame = cls._transform_frame(src.convert('RGBA'), sticker_type, working_size)
-            frames.append(frame)
-            durations.append(src.info.get('duration', cls.DEFAULT_FRAME_DURATION_MS))
+            frames.append(cls._transform_frame(src.convert('RGBA'), sticker_type, working_size))
 
         output = io.BytesIO()
         frames[0].save(
@@ -74,11 +76,33 @@ class StickerCreator:
             format='WEBP',
             save_all=True,
             append_images=frames[1:],
-            duration=durations,
+            duration=per_frame_ms,
             loop=0,
             quality=quality,
         )
         return output.getvalue()
+
+    @classmethod
+    def _parse_webp_durations(cls, buffer: bytes, n_frames: int) -> list[int]:
+        # PIL's WEBP reader does not surface per-frame durations reliably
+        # (returns None/0 for many inputs), so read them straight from ANMF
+        # chunks in the RIFF container.
+        durations: list[int] = []
+        header_size = 8
+        pos = 12
+        while pos + header_size <= len(buffer):
+            fourcc = buffer[pos : pos + 4]
+            chunk_size = int.from_bytes(buffer[pos + 4 : pos + header_size], 'little')
+            if fourcc == b'ANMF':
+                start = pos + header_size + cls.ANMF_DURATION_OFFSET
+                end = start + cls.ANMF_DURATION_SIZE
+                if end <= len(buffer):
+                    raw = int.from_bytes(buffer[start:end], 'little')
+                    durations.append(raw or cls.DEFAULT_FRAME_DURATION_MS)
+            pos += header_size + chunk_size + (chunk_size & 1)
+        while len(durations) < n_frames:
+            durations.append(cls.DEFAULT_FRAME_DURATION_MS)
+        return durations[:n_frames]
 
     @classmethod
     def _transform_frame(

--- a/bot/domain/services/sticker_creator.py
+++ b/bot/domain/services/sticker_creator.py
@@ -19,6 +19,8 @@ class StickerCreator:
     MIN_ANIMATED_WEBP_LEN = 21
     WEBP_ANIMATION_FLAG = 0x02
     DEFAULT_FRAME_DURATION_MS = 100
+    MAX_FRAME_STRIDE = 4
+    MAX_ANIMATED_STICKER_BYTES = 500_000
     ANMF_DURATION_OFFSET = 12
     ANMF_DURATION_SIZE = 3
 
@@ -65,18 +67,39 @@ class StickerCreator:
         n_frames = getattr(src, 'n_frames', 1)
         per_frame_ms = cls._parse_webp_durations(buffer, n_frames)
 
-        frames: list[Image.Image] = []
-        for index in range(n_frames):
-            src.seek(index)
-            frames.append(cls._transform_frame(src.convert('RGBA'), sticker_type, working_size))
+        all_frames: list[Image.Image] = []
+        for i in range(n_frames):
+            src.seek(i)
+            all_frames.append(cls._transform_frame(src.convert('RGBA'), sticker_type, working_size))
 
+        # Reduction degrades quality + pixelation; only drop frames as a last
+        # resort when pixelation breaks inter-frame compression and the file
+        # exceeds the animated-sticker limit.
+        output = b''
+        max_stride = min(cls.MAX_FRAME_STRIDE, max(1, n_frames // 2))
+        for stride in range(1, max_stride + 1):
+            output = cls._encode_animated_webp(all_frames, per_frame_ms, stride, quality)
+            if len(output) <= cls.MAX_ANIMATED_STICKER_BYTES:
+                return output
+        return output
+
+    @classmethod
+    def _encode_animated_webp(
+        cls,
+        all_frames: list[Image.Image],
+        per_frame_ms: list[int],
+        stride: int,
+        quality: int,
+    ) -> bytes:
+        frames = all_frames[::stride]
+        durations = [sum(per_frame_ms[i : i + stride]) for i in range(0, len(all_frames), stride)]
         output = io.BytesIO()
         frames[0].save(
             output,
             format='WEBP',
             save_all=True,
             append_images=frames[1:],
-            duration=per_frame_ms,
+            duration=durations,
             loop=0,
             quality=quality,
         )

--- a/bot/domain/services/sticker_creator.py
+++ b/bot/domain/services/sticker_creator.py
@@ -16,6 +16,9 @@ class StickerCreator:
     DEFAULT_PACK = 'Resenha'
     DEFAULT_AUTHOR = 'Resenhazord2'
     MIN_VIDEO_SIGNATURE_LEN = 12
+    MIN_ANIMATED_WEBP_LEN = 21
+    WEBP_ANIMATION_FLAG = 0x02
+    DEFAULT_FRAME_DURATION_MS = 100
 
     @classmethod
     async def create(
@@ -28,6 +31,8 @@ class StickerCreator:
         working_size = cls._effective_working_size(quality_reduction)
         if cls._is_video(buffer):
             return await cls._create_from_video(buffer, quality, working_size)
+        if cls._is_animated_webp(buffer):
+            return cls._create_from_animated_webp(buffer, sticker_type, quality, working_size)
         return cls._create_from_image(buffer, sticker_type, quality, working_size)
 
     @classmethod
@@ -45,7 +50,40 @@ class StickerCreator:
         cls, buffer: bytes, sticker_type: str, quality: int, working_size: int
     ) -> bytes:
         img = Image.open(io.BytesIO(buffer)).convert('RGBA')
+        img = cls._transform_frame(img, sticker_type, working_size)
+        output = io.BytesIO()
+        img.save(output, format='WEBP', quality=quality)
+        return output.getvalue()
 
+    @classmethod
+    def _create_from_animated_webp(
+        cls, buffer: bytes, sticker_type: str, quality: int, working_size: int
+    ) -> bytes:
+        src = Image.open(io.BytesIO(buffer))
+        frames: list[Image.Image] = []
+        durations: list[int] = []
+        for index in range(getattr(src, 'n_frames', 1)):
+            src.seek(index)
+            frame = cls._transform_frame(src.convert('RGBA'), sticker_type, working_size)
+            frames.append(frame)
+            durations.append(src.info.get('duration', cls.DEFAULT_FRAME_DURATION_MS))
+
+        output = io.BytesIO()
+        frames[0].save(
+            output,
+            format='WEBP',
+            save_all=True,
+            append_images=frames[1:],
+            duration=durations,
+            loop=0,
+            quality=quality,
+        )
+        return output.getvalue()
+
+    @classmethod
+    def _transform_frame(
+        cls, img: Image.Image, sticker_type: str, working_size: int
+    ) -> Image.Image:
         match sticker_type:
             case 'crop':
                 img = ImageOps.fit(img, cls.STICKER_SIZE)
@@ -55,13 +93,9 @@ class StickerCreator:
                 img = cls._apply_rounded_mask(img)
             case _:  # full
                 img = cls._contain_on_transparent(img)
-
         if working_size < cls.STICKER_SIZE[0]:
             img = cls._pixelate(img, working_size)
-
-        output = io.BytesIO()
-        img.save(output, format='WEBP', quality=quality)
-        return output.getvalue()
+        return img
 
     @classmethod
     def _pixelate(cls, img: Image.Image, working_size: int) -> Image.Image:
@@ -154,3 +188,13 @@ class StickerCreator:
             return True
         # MKV/WebM
         return buffer[:4] == b'\x1a\x45\xdf\xa3'
+
+    @classmethod
+    def _is_animated_webp(cls, buffer: bytes) -> bool:
+        if len(buffer) < cls.MIN_ANIMATED_WEBP_LEN:
+            return False
+        if buffer[:4] != b'RIFF' or buffer[8:12] != b'WEBP':
+            return False
+        if buffer[12:16] != b'VP8X':
+            return False
+        return bool(buffer[20] & cls.WEBP_ANIMATION_FLAG)

--- a/tests/unit/services/test_sticker_creator.py
+++ b/tests/unit/services/test_sticker_creator.py
@@ -322,3 +322,35 @@ class TestStickerCreatorAnimatedWebp:
         img = self._open_webp(result)
         assert img.size == StickerCreator.STICKER_SIZE
         assert getattr(img, 'is_animated', False)
+
+    def test_parse_webp_durations_reads_anmf_chunks(self) -> None:
+        frames = [Image.new('RGBA', (64, 64), c) for c in ('red', 'blue', 'green', 'yellow')]
+        buf = io.BytesIO()
+        frames[0].save(
+            buf,
+            format='WEBP',
+            save_all=True,
+            append_images=frames[1:],
+            duration=[40, 60, 80, 120],
+            loop=0,
+        )
+
+        durations = StickerCreator._parse_webp_durations(buf.getvalue(), n_frames=4)
+
+        assert durations == [40, 60, 80, 120]
+
+    def test_parse_webp_durations_substitutes_default_for_zero(self) -> None:
+        frames = [Image.new('RGBA', (64, 64), c) for c in ('red', 'blue')]
+        buf = io.BytesIO()
+        frames[0].save(
+            buf,
+            format='WEBP',
+            save_all=True,
+            append_images=frames[1:],
+            duration=0,
+            loop=0,
+        )
+
+        durations = StickerCreator._parse_webp_durations(buf.getvalue(), n_frames=2)
+
+        assert all(d == StickerCreator.DEFAULT_FRAME_DURATION_MS for d in durations)

--- a/tests/unit/services/test_sticker_creator.py
+++ b/tests/unit/services/test_sticker_creator.py
@@ -323,6 +323,54 @@ class TestStickerCreatorAnimatedWebp:
         assert img.size == StickerCreator.STICKER_SIZE
         assert getattr(img, 'is_animated', False)
 
+    @pytest.mark.anyio
+    async def test_moderate_reduction_keeps_all_frames(self) -> None:
+        eight_colors = ('red', 'blue', 'green', 'yellow', 'cyan', 'magenta', 'white', 'black')
+        animated = _create_animated_webp(colors=eight_colors)
+
+        result = await StickerCreator.create(animated, 'full', quality_reduction=50)
+
+        img = self._open_webp(result)
+        assert getattr(img, 'is_animated', False)
+        assert getattr(img, 'n_frames', 0) == 8
+
+    @pytest.mark.anyio
+    async def test_heavy_reduction_shrinks_output(self) -> None:
+        sixteen_colors = tuple(f'#{i * 16:02x}{255 - i * 16:02x}80' for i in range(16))
+        animated = _create_animated_webp(width=512, height=512, colors=sixteen_colors)
+
+        baseline = await StickerCreator.create(animated, 'full', quality_reduction=0)
+        heavy = await StickerCreator.create(animated, 'full', quality_reduction=95)
+
+        assert len(heavy) < len(baseline)
+
+    @pytest.mark.anyio
+    async def test_output_fits_animated_sticker_limit(self) -> None:
+        from PIL import ImageDraw
+
+        frames = []
+        for i in range(40):
+            img = Image.new('RGBA', (512, 512), (0, 0, 0, 0))
+            draw = ImageDraw.Draw(img)
+            color = (255 - i * 6 % 256, i * 12 % 256, 128, 255)
+            cx = 256 + int(80 * (i - 20) / 40)
+            draw.ellipse((cx - 128, 128, cx + 128, 384), fill=color)
+            frames.append(img)
+        buf = io.BytesIO()
+        frames[0].save(
+            buf,
+            format='WEBP',
+            save_all=True,
+            append_images=frames[1:],
+            duration=80,
+            loop=0,
+            quality=80,
+        )
+
+        heavy = await StickerCreator.create(buf.getvalue(), 'full', quality_reduction=99)
+
+        assert len(heavy) <= StickerCreator.MAX_ANIMATED_STICKER_BYTES
+
     def test_parse_webp_durations_reads_anmf_chunks(self) -> None:
         frames = [Image.new('RGBA', (64, 64), c) for c in ('red', 'blue', 'green', 'yellow')]
         buf = io.BytesIO()

--- a/tests/unit/services/test_sticker_creator.py
+++ b/tests/unit/services/test_sticker_creator.py
@@ -14,6 +14,31 @@ def _create_test_image(width: int = 100, height: int = 80, color: str = 'red') -
     return buf.getvalue()
 
 
+def _create_animated_webp(
+    width: int = 100,
+    height: int = 80,
+    colors: tuple[str, ...] = ('red', 'blue', 'green'),
+) -> bytes:
+    frames = [Image.new('RGBA', (width, height), c) for c in colors]
+    buf = io.BytesIO()
+    frames[0].save(
+        buf,
+        format='WEBP',
+        save_all=True,
+        append_images=frames[1:],
+        duration=100,
+        loop=0,
+    )
+    return buf.getvalue()
+
+
+def _create_static_webp(width: int = 100, height: int = 80, color: str = 'red') -> bytes:
+    img = Image.new('RGBA', (width, height), color)
+    buf = io.BytesIO()
+    img.save(buf, format='WEBP')
+    return buf.getvalue()
+
+
 class TestStickerCreatorImage:
     @staticmethod
     def _webp_to_image(webp_bytes: bytes) -> Image.Image:
@@ -215,3 +240,85 @@ class TestIsVideo:
 
     def test_short_buffer_not_video(self) -> None:
         assert not StickerCreator._is_video(b'\x00\x00')
+
+
+class TestIsAnimatedWebp:
+    def test_animated_webp_detected(self) -> None:
+        assert StickerCreator._is_animated_webp(_create_animated_webp())
+
+    def test_static_webp_not_detected(self) -> None:
+        assert not StickerCreator._is_animated_webp(_create_static_webp())
+
+    def test_png_not_detected(self) -> None:
+        assert not StickerCreator._is_animated_webp(_create_test_image())
+
+    def test_mp4_not_detected(self) -> None:
+        assert not StickerCreator._is_animated_webp(b'\x00\x00\x00\x1cftypisom' + b'\x00' * 20)
+
+    def test_short_buffer_not_detected(self) -> None:
+        assert not StickerCreator._is_animated_webp(b'RIFF\x00\x00\x00\x00WEBP')
+
+
+class TestStickerCreatorAnimatedWebp:
+    @staticmethod
+    def _open_webp(webp_bytes: bytes) -> Image.Image:
+        return Image.open(io.BytesIO(webp_bytes))
+
+    @pytest.mark.anyio
+    async def test_animated_webp_preserves_animation(self) -> None:
+        animated = _create_animated_webp(colors=('red', 'blue', 'green'))
+
+        result = await StickerCreator.create(animated, 'full')
+
+        img = self._open_webp(result)
+        assert getattr(img, 'is_animated', False)
+        assert getattr(img, 'n_frames', 0) == 3
+
+    @pytest.mark.anyio
+    async def test_animated_webp_resized_to_sticker_size(self) -> None:
+        animated = _create_animated_webp(width=200, height=150)
+
+        result = await StickerCreator.create(animated, 'full')
+
+        img = self._open_webp(result)
+        assert img.size == (512, 512)
+
+    @pytest.mark.anyio
+    async def test_animated_webp_skips_ffmpeg(self, mocker) -> None:
+        mock_exec = mocker.patch(
+            'bot.domain.services.sticker_creator.asyncio.create_subprocess_exec',
+        )
+
+        await StickerCreator.create(_create_animated_webp(), 'full')
+
+        mock_exec.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_static_webp_routes_to_image_path(self, mocker) -> None:
+        mock_exec = mocker.patch(
+            'bot.domain.services.sticker_creator.asyncio.create_subprocess_exec',
+        )
+
+        result = await StickerCreator.create(_create_static_webp(), 'full')
+
+        mock_exec.assert_not_called()
+        img = self._open_webp(result)
+        assert not getattr(img, 'is_animated', False)
+
+    @pytest.mark.anyio
+    async def test_animated_webp_quality_reduction_passed_to_pil(self, mocker) -> None:
+        save_spy = mocker.spy(Image.Image, 'save')
+
+        await StickerCreator.create(_create_animated_webp(), 'full', quality_reduction=50)
+
+        assert save_spy.call_args.kwargs['quality'] == 25
+
+    @pytest.mark.anyio
+    async def test_animated_webp_quality_reduction_pixelates_frames(self) -> None:
+        animated = _create_animated_webp(width=256, height=256)
+
+        result = await StickerCreator.create(animated, 'full', quality_reduction=90)
+
+        img = self._open_webp(result)
+        assert img.size == StickerCreator.STICKER_SIZE
+        assert getattr(img, 'is_animated', False)


### PR DESCRIPTION
## Summary
- **fix**: detect animated WEBP (VP8X animation flag) and route it through PIL frame iteration. ffmpeg's native webp decoder skips `ANIM`/`ANMF` chunks, so PIL is used instead of the video pipeline
- **feat**: `,stic -X%` option (1–99) that reduces encoder quality *and* pixelates resolution via bilinear-down + nearest-up — applied to images, videos, *and* animated stickers (per frame)
- Shared `_transform_frame(img, sticker_type, working_size)` helper applies sticker-type masks and pixelation for every frame in all three pipelines

## Scope
Supersedes #56 — the standalone quality-reduction PR did not know about the animated-webp path, so `-X%` had no effect when the input was an animated sticker. Combining them here ensures parity across all three input types.

## Bug background
Replying `,stic` to an animated sticker produced a static sticker. `_is_video` only matched MP4/AVI/MKV signatures; animated WEBP fell through to `_create_from_image`, collapsing to a single frame. Once animation was preserved, the user tested `-X%` on animated input and the reduction was visibly weaker than on GIF/image input — because `_create_from_animated_webp` was hardcoding `WEBP_QUALITY` and skipping pixelation.

## Test plan
- [x] `uv run pytest` — 1903 passed
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run basedpyright` — 0 errors
- [x] End-to-end: 3-frame animated WEBP at `-0%`, `-50%`, `-95%` all preserve `is_animated=True, n_frames=3`
- [ ] Manual WhatsApp: reply `,stic` to animated sticker — animation preserved
- [ ] Manual WhatsApp: reply `,stic -50%` / `,stic -95%` to animated sticker — pixelation visibly stronger
- [ ] Manual WhatsApp: reply `,stic -50%` to GIF — reduction unchanged
- [ ] Manual WhatsApp: reply `,stic -50%` to image — reduction unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)