### PR TITLE
chore: adopt git flow with develop integration branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,41 @@
+# Release PR: `develop` → `main`
+
+> **Merge strategy: "Create a merge commit". Do NOT squash.**
+>
+> Squashing collapses every Conventional Commit into a single subject and breaks semantic-release version inference.
+> See [docs/git-flow.md](../../docs/git-flow.md#release-workflow-develop--main).
+
+## Highlights
+
+<!-- Group the accumulated changes by type -->
+
+### ✨ Features (`feat`)
+
+-
+
+### 🐛 Fixes (`fix`)
+
+-
+
+### 💥 Breaking changes
+
+-
+
+### Other
+
+- <!-- chore / docs / refactor / perf / test / ci -->
+
+## Deploy impact
+
+- [ ] New env vars / secrets required (list below, and add to `.env.example`)
+- [ ] Schema / data migrations included
+- [ ] Rollback plan if deploy fails
+
+<!-- Details: -->
+
+## Pre-merge checklist
+
+- [ ] CI green on this PR
+- [ ] `develop` has no conflicts with `main`
+- [ ] Highlights list matches the commit range (`git log main..develop --oneline`)
+- [ ] Merge button set to **"Create a merge commit"**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- 1-3 bullets of what this PR changes and why -->
+
+-
+
+## Type
+
+<!-- Keep the ones that apply -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `refactor` — restructure without behavior change
+- [ ] `perf` — performance
+- [ ] `test` — add/update tests
+- [ ] `docs` — documentation
+- [ ] `chore` / `build` / `ci` — tooling, config, pipelines
+
+## Test plan
+
+<!-- How was this tested? Include commands, scenarios, edge cases -->
+
+- [ ]
+
+## Target branch
+
+This PR targets `develop` (default). Hotfixes target `main` instead — see [docs/git-flow.md](../docs/git-flow.md).

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/docs/git-flow.md
+++ b/docs/git-flow.md
@@ -47,13 +47,68 @@ refactor: move TypeScript service to gateway/
 test: add Python unit and integration test structure
 ```
 
-## Protected Main
+## Branches
 
-Protected `main` branch — all changes via PR only:
+This project uses a **two-permanent-branch** flow. Direct pushes to either are blocked — all changes go through PRs.
 
-1. Branch from `main`: `git checkout -b feature/description`
-2. Make commits with conventional commits
-3. Push and open PR against `main`
-4. Require 1+ approval, CI passing
-5. Squash merge to `main`
+| Branch    | Purpose                                                            | Default | Auto-release |
+| --------- | ------------------------------------------------------------------ | ------- | ------------ |
+| `main`    | Production. `Pipeline` workflow runs deploy + semantic-release.    | No      | Yes          |
+| `develop` | Integration. Accumulates PRs between releases.                     | Yes     | No           |
+
+### Short-lived branches
+
+| Prefix                                                   | Forks from | PRs into                                | Example                        |
+| -------------------------------------------------------- | ---------- | --------------------------------------- | ------------------------------ |
+| `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `chore/*`, … | `develop`  | `develop`                               | `feat/add-fipe-command`        |
+| `hotfix/*`                                               | `main`     | `main` (then back-merge into `develop`) | `hotfix/fix-cache-timeout`     |
+
+## Daily workflow (features / fixes / chores)
+
+1. Sync: `git checkout develop && git pull`
+2. Branch: `git checkout -b feat/description`
+3. Commit using Conventional Commits (atomic — one logical change per commit)
+4. Push and open PR **targeting `develop`**
+5. Require CI green + 1 approval, then **squash merge**
 6. Delete branch after merge
+
+The squash-merge commit subject **must itself be a Conventional Commit** (`feat: …`, `fix(scope): …`, …) — semantic-release reads every commit that lands on `main` later and infers the version bump from these subjects.
+
+## Release workflow (`develop` → `main`)
+
+When `develop` has accumulated enough changes to release:
+
+1. Open a PR **from `develop` into `main`** using the Release PR template (append `?template=release.md` to the PR URL, or pick it from the template dropdown).
+2. Confirm CI is green.
+3. **Merge with "Create a merge commit"** — not squash, not rebase. This is **mandatory**.
+
+   Why: semantic-release analyzes every commit between the previous release tag and `main` to compute the next version. A squash would collapse many Conventional Commits into one subject and produce the wrong bump (e.g. hiding a `feat` behind a `chore` title). The merge commit preserves every `feat` / `fix` / `BREAKING CHANGE`.
+4. `Pipeline` runs automatically on `main`: lint → test → build → deploy → semantic-release → new tag + `CHANGELOG.md`.
+
+## Hotfix workflow
+
+For urgent production fixes that can't wait for the next release:
+
+1. `git checkout main && git pull && git checkout -b hotfix/description`
+2. Fix, commit with Conventional Commits, push
+3. Open PR targeting `main`
+4. Merge with **"Create a merge commit"** (same reason as release)
+5. Pipeline deploys and releases a patch version
+6. **Back-merge `main` into `develop`** so the fix is present on the integration branch:
+
+   ```
+   git checkout develop && git pull
+   git checkout -b chore/back-merge-main
+   git merge --no-ff main
+   ```
+
+   Push and open a PR into `develop` (merge commit, not squash).
+
+## Merge-strategy summary
+
+| Merge target                   | Strategy                 | Reason                                                              |
+| ------------------------------ | ------------------------ | ------------------------------------------------------------------- |
+| `develop` ← feature/fix/chore  | **Squash**               | Clean history; squash subject itself is a Conventional Commit       |
+| `main` ← `develop`             | **Merge commit (`--no-ff`)** | Preserves every Conventional Commit for semantic-release         |
+| `main` ← `hotfix/*`            | **Merge commit**         | Same reason                                                         |
+| `develop` ← `main` (back-merge)| **Merge commit**         | Preserves hotfix history on `develop`                               |


### PR DESCRIPTION
## Summary

- Introduces a `develop` integration branch so PRs accumulate there and a single `develop` → `main` merge triggers one release, instead of one semantic-release run per PR.
- Adds CI on PRs targeting `develop` and documents daily / release / hotfix workflows.
- Adds a default PR template and a release PR template that enforces the merge-commit strategy.

## Why the merge-commit rule matters

Semantic-release analyses every commit between the previous tag and `main` to compute the next version. Squashing `develop` → `main` would collapse many Conventional Commits into one subject and produce the wrong bump (e.g. hiding a `feat` behind a `chore` title). The release template and docs both call this out explicitly.

## Merge strategies at a glance

| Target | Strategy |
| --- | --- |
| `develop` ← feature/fix/chore | Squash |
| `main` ← `develop` | Merge commit (`--no-ff`) |
| `main` ← `hotfix/*` | Merge commit |
| `develop` ← `main` (back-merge) | Merge commit |

## Follow-up after this PR merges

Not part of this PR — needs to run against GitHub state once `main` contains these docs:

1. Create `develop` from `main`: `git checkout main && git pull && git checkout -b develop && git push -u origin develop`
2. Set `develop` as the default branch (Settings → Branches)
3. Add branch protection to both `main` and `develop` (require PR + CI + 1 review; keep merge-commit enabled for `main`)
4. Verify release template works: open a dummy PR with `?template=release.md` appended to the URL

## Test plan

- [ ] CI green on this PR (the `Check` workflow should still run — PR targets `main`)
- [ ] `.github/PULL_REQUEST_TEMPLATE/release.md` renders via `?template=release.md` after merge
- [ ] First real `develop` → `main` release correctly bumps the version based on accumulated Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)