### PR TITLE
fix(ci): fix PSR version bump, add automated back-merge and deployment registration

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -147,13 +147,38 @@ jobs:
             "$VPS_USER@$VPS_HOST" \
             "cd $VPS_APP_DIR && git pull && docker compose pull && docker compose up -d --no-build"
 
-  # Stage 5: Release (after deploy)
+  # Stage 5: Register deployment (after deploy)
+  register-deploy:
+    name: Register GitHub deployment
+    runs-on: ubuntu-latest
+    needs: deploy
+    permissions:
+      deployments: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'main',
+              environment: 'production',
+              description: 'Deploy to Oracle VPS',
+              auto_merge: false,
+              required_contexts: []
+            })
+
+  # Stage 6: Release (after deploy)
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
     needs: deploy
     permissions:
       contents: write
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -167,6 +192,7 @@ jobs:
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
 
       - name: Run Semantic Release
+        id: release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           GIT_COMMITTER_NAME: semantic-release
@@ -174,3 +200,24 @@ jobs:
         run: |
           uvx python-semantic-release@10 -c semantic-release.toml version
           uvx python-semantic-release@10 -c semantic-release.toml publish
+
+  # Stage 7: Back-merge main into develop (after release)
+  backmerge:
+    name: Back-merge main into develop
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Merge main into develop
+        run: |
+          git fetch origin main
+          git merge --no-ff origin/main -m "chore: back-merge main into develop"
+          git push origin develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,122 @@
 
 <!-- version list -->
 
+## v1.5.2 (2026-05-05)
+
+### Bug Fixes
+
+- Resolve basedpyright and SonarQube issues
+  ([`260a060`](https://github.com/sandrosmarzaro/resenhazord2/commit/260a0605e4c5f211868d5acbd7ad096b64095b2e))
+
+- **agent**: Return user-friendly message when LLM providers unavailable
+  ([`8b3174f`](https://github.com/sandrosmarzaro/resenhazord2/commit/8b3174fe13238ec2a1d99f9fcd619209624871a6))
+
+- **build**: Configure hatchling backend to resolve flat-layout build error
+  ([`4810b51`](https://github.com/sandrosmarzaro/resenhazord2/commit/4810b5140e17d5a96b683b7f1a22a321d4314f9c))
+
+- **ci**: Move PSR config to pyproject.toml so v10 discovers it
+  ([`6149e5d`](https://github.com/sandrosmarzaro/resenhazord2/commit/6149e5d0eca677341a925414ad6690317c4751e8))
+
+- **ci**: Move PSR config to semantic-release.toml with -c flag
+  ([`5f6bdac`](https://github.com/sandrosmarzaro/resenhazord2/commit/5f6bdac54e2a551c8be24427fd1cb5fd90f3145d))
+
+- **discord**: Handle clarify and suggest builtin prefixes in agent router
+  ([`7314b3f`](https://github.com/sandrosmarzaro/resenhazord2/commit/7314b3f2d15b2cdd943dfb60cd006f2605093c2f))
+
+- **discord**: Suppress @everyone/@here pings in bot replies
+  ([`3788900`](https://github.com/sandrosmarzaro/resenhazord2/commit/3788900bea5b2901716aaad23a84eaea2987d4de))
+
+- **handler**: Return clarify fallback on ValueError instead of raw data
+  ([`885f861`](https://github.com/sandrosmarzaro/resenhazord2/commit/885f8611a708d37fafe0848a10baba9e96cb8df0))
+
+- **telegram**: Handle clarify and suggest builtin prefixes in agent router
+  ([`832b5df`](https://github.com/sandrosmarzaro/resenhazord2/commit/832b5df67dacc37e72ba950d114c7bd0c090cd7b))
+
+- **tests**: Add is_group flag to ws_handler no-match test
+  ([`1fc6119`](https://github.com/sandrosmarzaro/resenhazord2/commit/1fc6119befadd486cc48d4f5cd3154eb981011bf))
+
+### Chores
+
+- Replace slash commands with taskipy tasks, add complexity to pre-push hook
+  ([`0f972ce`](https://github.com/sandrosmarzaro/resenhazord2/commit/0f972ce7ce567c31c2a4daca92a47ccfe6f29b6a))
+
+- **deploy**: Export COMPOSE_BAKE=true for faster image builds
+  ([`af08d6a`](https://github.com/sandrosmarzaro/resenhazord2/commit/af08d6ad74c9ec7de71a999d9d4d0e77d3a88cde))
+
+- **deps**: Add radon and xenon for cyclomatic complexity gate
+  ([`bcdf46a`](https://github.com/sandrosmarzaro/resenhazord2/commit/bcdf46a46a006bb5a613edb7e12786ea658fe259))
+
+- **docker**: Enable COMPOSE_BAKE=true for faster builds
+  ([`cd560c9`](https://github.com/sandrosmarzaro/resenhazord2/commit/cd560c97ae88d2637efbf7511e3c47791aecfc9f))
+
+- **taskipy**: Add logrotate task to truncate docker.log
+  ([`88693bc`](https://github.com/sandrosmarzaro/resenhazord2/commit/88693bc00b73a17e016ff63e3fd4404309f031e4))
+
+- **taskipy**: Fix log task to show logs and save to file
+  ([`0c4b391`](https://github.com/sandrosmarzaro/resenhazord2/commit/0c4b3917217523ef6672d5ad86a954b3d653d5bc))
+
+### Continuous Integration
+
+- Remove C901/PLR0912 ignores, add complexity gate and explicit mccabe threshold
+  ([`2afaa9d`](https://github.com/sandrosmarzaro/resenhazord2/commit/2afaa9d9affc926876be19fda15c7c8837541c32))
+
+### Refactoring
+
+- Reduce CC to ≤10 for match_row_parser, standing_parser, agent_response, discord handler
+  ([`69eea4b`](https://github.com/sandrosmarzaro/resenhazord2/commit/69eea4b38825b03a15d6761c8f00166c47b2e58f))
+
+- **agent**: Extract shared prefix constants and fix inline literals
+  ([`9458bc1`](https://github.com/sandrosmarzaro/resenhazord2/commit/9458bc1f7eb9c29ffdde6ea83fa2675d2d1ac477))
+
+- **anime**: Extract methods to reduce execute CC from 19 to ≤10
+  ([`438ff8b`](https://github.com/sandrosmarzaro/resenhazord2/commit/438ff8b1393731230cc1efed5edb0d7e2f007923))
+
+- **caption**: Extract _resolve_country and reuse _stadium_lines to reduce build_bare CC from 11 to
+  ≤10
+  ([`f0e26a7`](https://github.com/sandrosmarzaro/resenhazord2/commit/f0e26a745f8ff606338af6d9a2e6972221003f93))
+
+- **football-player**: Extract _lookup method to reduce _build_caption CC from 13 to ≤10
+  ([`73ed087`](https://github.com/sandrosmarzaro/resenhazord2/commit/73ed0878a7d7740b02d9eb78ff6d302b9fc51ad2))
+
+- **football-team**: Extract methods to reduce _random_team CC from 15 to ≤10
+  ([`a69625c`](https://github.com/sandrosmarzaro/resenhazord2/commit/a69625ca129ca0b3280e1976f1f9118a1fb83a3f))
+
+- **lineup**: Extract _league_lineup and _resolve_global_pages to reduce build CC from 11 to ≤10
+  ([`727114f`](https://github.com/sandrosmarzaro/resenhazord2/commit/727114f03426754b474cfb3a2e23160a14b94f18))
+
+- **meal-recipes**: Extract methods to reduce _fetch_and_build CC from 12 to ≤10
+  ([`d34f450`](https://github.com/sandrosmarzaro/resenhazord2/commit/d34f450befbefa60692579b08d96642301e850b1))
+
+- **nhentai**: Extract _filter_tags and _find_tag to reduce _parse CC from 15 to ≤10
+  ([`b36979e`](https://github.com/sandrosmarzaro/resenhazord2/commit/b36979e7ea6dabddceda0193208ce27cd68a5144))
+
+- **rawg**: Extract _parse_game, _join_names, _join_nested to reduce fetch CC from 13 to ≤10
+  ([`50a1531`](https://github.com/sandrosmarzaro/resenhazord2/commit/50a153117735aa2e8bb0285cc6efa1f43a489182))
+
+- **score**: Extract methods to reduce execute CC from 20 to ≤10
+  ([`00b9fb9`](https://github.com/sandrosmarzaro/resenhazord2/commit/00b9fb999d5a9f3d23b0bdea38779deda05c4088))
+
+- **thesportsdb**: Extract _score_candidate to reduce find_best_match CC from 12 to ≤10
+  ([`9c98055`](https://github.com/sandrosmarzaro/resenhazord2/commit/9c98055ffa8de6eabaccc2163fb811f0c78609f1))
+
+### Testing
+
+- Add coverage for extracted methods, fix type annotations and module-level constant
+  ([`adbe0f1`](https://github.com/sandrosmarzaro/resenhazord2/commit/adbe0f1a21039b69b31374c2c34f6ef6a409f333))
+
+- **agent**: Cover empty clarify/suggest content guard
+  ([`10bd7b5`](https://github.com/sandrosmarzaro/resenhazord2/commit/10bd7b58a7f81aaf4f6ac0815f3cc6b0ce928701))
+
+- **agent**: Use shared constants, strengthen assertions, test through public API
+  ([`d9f034c`](https://github.com/sandrosmarzaro/resenhazord2/commit/d9f034c3af5ad3eca46e39b89bd29b68eb23acdf))
+
+- **constants**: Add smoke tests for shared prefix and marker constants
+  ([`d1665d4`](https://github.com/sandrosmarzaro/resenhazord2/commit/d1665d4e657703f12d1006bd114cd23d787bdaaf))
+
+- **handler**: Cover empty clarify/suggest prefix fallback
+  ([`429284c`](https://github.com/sandrosmarzaro/resenhazord2/commit/429284cf8914f8a872a50e1affbe50b8a8d85463))
+
+
 ## v1.5.1 (2026-05-04)
 
 ### Bug Fixes

--- a/docs/git-flow.md
+++ b/docs/git-flow.md
@@ -83,14 +83,8 @@ When `develop` has accumulated enough changes to release:
 3. **Merge with "Create a merge commit"** — not squash, not rebase. This is **mandatory**.
 
    Why: semantic-release analyzes every commit between the previous release tag and `main` to compute the next version. A squash would collapse many Conventional Commits into one subject and produce the wrong bump (e.g. hiding a `feat` behind a `chore` title). The merge commit preserves every `feat` / `fix` / `BREAKING CHANGE`.
-4. `Pipeline` runs automatically on `main`: lint → test → build → deploy → semantic-release → new tag + `CHANGELOG.md`.
-5. **Back-merge `main` into `develop`** locally (no PR needed):
-
-   ```bash
-   git checkout develop && git pull
-   git merge --no-ff main -m "chore: back-merge main into develop"
-   git push origin develop
-   ```
+4. `Pipeline` runs automatically on `main`: lint → test → build → deploy → register deployment → semantic-release → new tag + `CHANGELOG.md`.
+5. **Back-merge is automatic** — the `backmerge` job in `Pipeline` merges `main` into `develop` after a successful release. No manual step needed.
 
 ## Hotfix workflow
 
@@ -100,14 +94,7 @@ For urgent production fixes that can't wait for the next release:
 2. Fix, commit with Conventional Commits, push
 3. Open PR targeting `main`
 4. Merge with **"Create a merge commit"** (same reason as release)
-5. Pipeline deploys and releases a patch version
-6. **Back-merge `main` into `develop`** locally (no PR needed):
-
-   ```bash
-   git checkout develop && git pull
-   git merge --no-ff main -m "chore: back-merge main into develop"
-   git push origin develop
-   ```
+5. Pipeline deploys and releases a patch version. Back-merge to develop is automatic via the `backmerge` job.
 
 ## Merge-strategy summary
 
@@ -116,4 +103,4 @@ For urgent production fixes that can't wait for the next release:
 | `develop` ← feature/fix/chore  | **Squash**               | Clean history; squash subject itself is a Conventional Commit       |
 | `main` ← `develop`             | **Merge commit (`--no-ff`)** | Preserves every Conventional Commit for semantic-release         |
 | `main` ← `hotfix/*`            | **Merge commit**         | Same reason                                                         |
-| `develop` ← `main` (back-merge)| **Local merge, no PR**    | Avoids duplicate CI runs; commits already vetted on main            |
+| `develop` ← `main` (back-merge)| **CI automated `--no-ff`** | Pipeline `backmerge` job; no manual step needed                   |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "resenhazord2-core"
-version = "0.1.0"
+version = "1.5.2"
 description = "Python core for Resenhazord2 WhatsApp bot"
 requires-python = ">=3.13"
 dependencies = [

--- a/semantic-release.toml
+++ b/semantic-release.toml
@@ -1,6 +1,10 @@
 [semantic_release]
-version_toml = ["pyproject.toml:project.version"]
-build_command = "uv build"
+version_variables = ["pyproject.toml:project.version"]
+build_command = """
+    uv lock --upgrade-package "$PACKAGE_NAME"
+    git add uv.lock
+    uv build
+"""
 changelog_file = "CHANGELOG.md"
 
 [semantic_release.branches.main]


### PR DESCRIPTION
## Problem

Three issues with the current release pipeline:

1. **Version never bumps in `pyproject.toml`** — PSR v10 renamed `version_toml` → `version_variables`. The old key is silently ignored, so `project.version` stays at `0.1.0` despite tags (v1.5.0, v1.5.1, v1.5.2) being created.

2. **No automated back-merge** — every release requires a manual `git merge --no-ff main` into develop. This is the pain point you highlighted.

3. **No GitHub Deployments** — the `/deployments` page shows stale Railway entries because the SSH deploy step doesn't register with GitHub.

## Changes

### `semantic-release.toml`
- Rename `version_toml` → `version_variables` (PSR v10 breaking change)
- Update `build_command` to sync `uv.lock` before building (per PSR uv integration guide):
  ```
  uv lock --upgrade-package "$PACKAGE_NAME"
  git add uv.lock
  uv build
  ```

### `.github/workflows/pipeline.yml`
- **`register-deploy`** job (after deploy): creates a GitHub Deployment via `actions/github-script@v7`
- **`release`** job: expose outputs (`released`, `version`, `tag`) from PSR step
- **`backmerge`** job (after release): auto-merges `main` into `develop` with `--no-ff`, gated on `released == 'true'`

### `docs/git-flow.md`
- Updated release workflow: back-merge is now automated, removed manual steps
- Updated hotfix workflow: back-merge is now automated
- Updated merge-strategy table: `develop ← main` is CI-automated

## After merge
The next release PR (develop → main) will trigger PSR with the correct config. It should:
1. Compute the right version (1.5.3 or 1.6.0 depending on commits)
2. Bump `pyproject.toml:project.version`
3. Update `CHANGELOG.md`
4. Tag the release
5. Auto-back-merge into develop
6. Register a GitHub deployment