### PR TITLE
release: develop → main

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -147,13 +147,38 @@ jobs:
             "$VPS_USER@$VPS_HOST" \
             "cd $VPS_APP_DIR && git pull && docker compose pull && docker compose up -d --no-build"
 
-  # Stage 5: Release (after deploy)
+  # Stage 5: Register deployment (after deploy)
+  register-deploy:
+    name: Register GitHub deployment
+    runs-on: ubuntu-latest
+    needs: deploy
+    permissions:
+      deployments: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'main',
+              environment: 'production',
+              description: 'Deploy to Oracle VPS',
+              auto_merge: false,
+              required_contexts: []
+            })
+
+  # Stage 6: Release (after deploy)
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
     needs: deploy
     permissions:
       contents: write
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -167,6 +192,7 @@ jobs:
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
 
       - name: Run Semantic Release
+        id: release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           GIT_COMMITTER_NAME: semantic-release
@@ -174,3 +200,24 @@ jobs:
         run: |
           uvx python-semantic-release@10 -c semantic-release.toml version
           uvx python-semantic-release@10 -c semantic-release.toml publish
+
+  # Stage 7: Back-merge main into develop (after release)
+  backmerge:
+    name: Back-merge main into develop
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Merge main into develop
+        run: |
+          git fetch origin main
+          git merge --no-ff origin/main -m "chore: back-merge main into develop"
+          git push origin develop

--- a/bot/adapters/telegram/bot.py
+++ b/bot/adapters/telegram/bot.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar
 import sentry_sdk
 import structlog
 from telegram import BotCommand, BotCommandScopeChat, Update
-from telegram.error import NetworkError, TelegramError
+from telegram.error import NetworkError, RetryAfter, TelegramError
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 
 from bot.adapters.telegram.adapter import TelegramBotAdapter
@@ -45,6 +45,7 @@ class TelegramBot:
         )
         self._handler = TelegramUpdateHandler(bot_username, nsfw_chat_ids)
         self._nsfw_chat_ids = nsfw_chat_ids
+        self._original_updater_level = _UPDATER_LOGGER.level
 
     async def start(self) -> None:
         self._app.add_error_handler(self._handle_error)
@@ -62,6 +63,7 @@ class TelegramBot:
             await self._app.updater.stop()
         await self._app.stop()
         await self._app.shutdown()
+        _UPDATER_LOGGER.setLevel(self._original_updater_level)
         logger.info('telegram_stopped')
 
     def _register_handlers(self) -> None:
@@ -99,8 +101,11 @@ class TelegramBot:
 
     async def _handle_error(self, _update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
         error = context.error
-        if isinstance(error, NetworkError):
-            logger.warning('telegram_network_error', error=str(error))
+        if error is None:
+            logger.warning('telegram_error_missing')
+            return
+        if isinstance(error, NetworkError | RetryAfter):
+            logger.warning('telegram_transient_error', error=str(error))
             return
         logger.exception('telegram_unexpected_error', error=str(error))
         sentry_sdk.capture_exception(error)

--- a/bot/adapters/telegram/bot.py
+++ b/bot/adapters/telegram/bot.py
@@ -1,17 +1,21 @@
+import logging
 import re
 import unicodedata
 from collections.abc import Callable, Coroutine
 from typing import Any, ClassVar
 
+import sentry_sdk
 import structlog
 from telegram import BotCommand, BotCommandScopeChat, Update
-from telegram.error import TelegramError
+from telegram.error import NetworkError, TelegramError
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 
 from bot.adapters.telegram.adapter import TelegramBotAdapter
 from bot.adapters.telegram.handler import TelegramUpdateHandler
 from bot.application.command_registry import CommandRegistry
 from bot.domain.commands.base import Command, CommandScope, Platform
+
+_UPDATER_LOGGER = logging.getLogger('telegram.ext.Updater')
 
 logger = structlog.get_logger()
 
@@ -43,6 +47,8 @@ class TelegramBot:
         self._nsfw_chat_ids = nsfw_chat_ids
 
     async def start(self) -> None:
+        self._app.add_error_handler(self._handle_error)
+        _UPDATER_LOGGER.setLevel(logging.CRITICAL)
         self._register_handlers()
         await self._app.initialize()
         await self._app.start()
@@ -90,6 +96,14 @@ class TelegramBot:
             await handler.handle(port, update)
 
         return callback
+
+    async def _handle_error(self, _update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+        error = context.error
+        if isinstance(error, NetworkError):
+            logger.warning('telegram_network_error', error=str(error))
+            return
+        logger.exception('telegram_unexpected_error', error=str(error))
+        sentry_sdk.capture_exception(error)
 
     async def _publish_command_menu(self) -> None:
         public = self._bot_commands_for_scopes({self.PUBLIC_SCOPE})

--- a/docs/git-flow.md
+++ b/docs/git-flow.md
@@ -83,14 +83,8 @@ When `develop` has accumulated enough changes to release:
 3. **Merge with "Create a merge commit"** — not squash, not rebase. This is **mandatory**.
 
    Why: semantic-release analyzes every commit between the previous release tag and `main` to compute the next version. A squash would collapse many Conventional Commits into one subject and produce the wrong bump (e.g. hiding a `feat` behind a `chore` title). The merge commit preserves every `feat` / `fix` / `BREAKING CHANGE`.
-4. `Pipeline` runs automatically on `main`: lint → test → build → deploy → semantic-release → new tag + `CHANGELOG.md`.
-5. **Back-merge `main` into `develop`** locally (no PR needed):
-
-   ```bash
-   git checkout develop && git pull
-   git merge --no-ff main -m "chore: back-merge main into develop"
-   git push origin develop
-   ```
+4. `Pipeline` runs automatically on `main`: lint → test → build → deploy → register deployment → semantic-release → new tag + `CHANGELOG.md`.
+5. **Back-merge is automatic** — the `backmerge` job in `Pipeline` merges `main` into `develop` after a successful release. No manual step needed.
 
 ## Hotfix workflow
 
@@ -100,14 +94,7 @@ For urgent production fixes that can't wait for the next release:
 2. Fix, commit with Conventional Commits, push
 3. Open PR targeting `main`
 4. Merge with **"Create a merge commit"** (same reason as release)
-5. Pipeline deploys and releases a patch version
-6. **Back-merge `main` into `develop`** locally (no PR needed):
-
-   ```bash
-   git checkout develop && git pull
-   git merge --no-ff main -m "chore: back-merge main into develop"
-   git push origin develop
-   ```
+5. Pipeline deploys and releases a patch version. Back-merge to develop is automatic via the `backmerge` job.
 
 ## Merge-strategy summary
 
@@ -116,4 +103,4 @@ For urgent production fixes that can't wait for the next release:
 | `develop` ← feature/fix/chore  | **Squash**               | Clean history; squash subject itself is a Conventional Commit       |
 | `main` ← `develop`             | **Merge commit (`--no-ff`)** | Preserves every Conventional Commit for semantic-release         |
 | `main` ← `hotfix/*`            | **Merge commit**         | Same reason                                                         |
-| `develop` ← `main` (back-merge)| **Local merge, no PR**    | Avoids duplicate CI runs; commits already vetted on main            |
+| `develop` ← `main` (back-merge)| **CI automated `--no-ff`** | Pipeline `backmerge` job; no manual step needed                   |

--- a/semantic-release.toml
+++ b/semantic-release.toml
@@ -1,6 +1,10 @@
 [semantic_release]
-version_toml = ["pyproject.toml:project.version"]
-build_command = "uv build"
+version_variables = ["pyproject.toml:project.version"]
+build_command = """
+    uv lock --upgrade-package "$PACKAGE_NAME"
+    git add uv.lock
+    uv build
+"""
 changelog_file = "CHANGELOG.md"
 
 [semantic_release.branches.main]

--- a/tests/unit/adapters/telegram/test_bot.py
+++ b/tests/unit/adapters/telegram/test_bot.py
@@ -1,8 +1,9 @@
 import logging
 from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
-from telegram.error import NetworkError, TelegramError
+from telegram.error import NetworkError, RetryAfter, TelegramError
 
 from bot.adapters.telegram.bot import TelegramBot
 from bot.domain.commands.base import CommandScope, Platform
@@ -98,8 +99,7 @@ class TestStartStop:
 
     @pytest.mark.anyio
     async def test_start_suppresses_updater_logger(self, mocker):
-        updater_logger = logging.getLogger('telegram.ext.Updater')
-        original_level = updater_logger.level
+        mock_logger = mocker.MagicMock()
         bot = _make_bot(mocker)
         bot._app.initialize = mocker.AsyncMock()
         bot._app.start = mocker.AsyncMock()
@@ -107,12 +107,10 @@ class TestStartStop:
         bot._publish_command_menu = mocker.AsyncMock()
         _patch_registry(mocker, [])
 
-        try:
+        with patch('bot.adapters.telegram.bot._UPDATER_LOGGER', mock_logger):
             await bot.start()
 
-            assert updater_logger.level == logging.CRITICAL
-        finally:
-            updater_logger.setLevel(original_level or logging.NOTSET)
+        mock_logger.setLevel.assert_called_once_with(logging.CRITICAL)
 
     @pytest.mark.anyio
     async def test_start_without_updater_skips_polling(self, mocker):
@@ -152,6 +150,19 @@ class TestStartStop:
         await bot.stop()
 
         cast('Any', bot._app.stop).assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_stop_restores_updater_logger_level(self, mocker):
+        mock_logger = mocker.MagicMock()
+        bot = _make_bot(mocker)
+        bot._app.stop = mocker.AsyncMock()
+        bot._app.shutdown = mocker.AsyncMock()
+        bot._app.updater = None
+
+        with patch('bot.adapters.telegram.bot._UPDATER_LOGGER', mock_logger):
+            await bot.stop()
+
+        mock_logger.setLevel.assert_called_once_with(bot._original_updater_level)
 
 
 class TestRegisterHandlers:
@@ -308,39 +319,38 @@ class TestPublishCommandMenu:
 
 class TestErrorHandler:
     @pytest.mark.anyio
-    async def test_network_error_logged_as_warning(self, mocker):
+    async def test_network_error_logged_as_warning_not_captured(self, mocker):
         bot = _make_bot(mocker)
         mock_logger = mocker.patch('bot.adapters.telegram.bot.logger')
+        capture = mocker.patch('bot.adapters.telegram.bot.sentry_sdk.capture_exception')
         context = mocker.MagicMock()
         context.error = NetworkError('[Errno -3] Try again')
 
         await bot._handle_error(object(), context)
 
         mock_logger.warning.assert_called_once_with(
-            'telegram_network_error',
+            'telegram_transient_error',
             error='[Errno -3] Try again',
         )
         mock_logger.exception.assert_not_called()
+        capture.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_non_network_error_logged_and_captured(self, mocker):
+    async def test_retry_after_logged_as_warning_not_captured(self, mocker):
         bot = _make_bot(mocker)
         mock_logger = mocker.patch('bot.adapters.telegram.bot.logger')
         capture = mocker.patch('bot.adapters.telegram.bot.sentry_sdk.capture_exception')
         context = mocker.MagicMock()
-        error = TelegramError('something broke')
-        context.error = error
+        context.error = RetryAfter(retry_after=30)
 
         await bot._handle_error(object(), context)
 
-        mock_logger.exception.assert_called_once_with(
-            'telegram_unexpected_error',
-            error='something broke',
-        )
-        capture.assert_called_once_with(error)
+        mock_logger.warning.assert_called_once()
+        mock_logger.exception.assert_not_called()
+        capture.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_unexpected_exception_logged_and_captured(self, mocker):
+    async def test_non_transient_error_logged_and_captured(self, mocker):
         bot = _make_bot(mocker)
         mock_logger = mocker.patch('bot.adapters.telegram.bot.logger')
         capture = mocker.patch('bot.adapters.telegram.bot.sentry_sdk.capture_exception')
@@ -355,3 +365,17 @@ class TestErrorHandler:
             error='oops',
         )
         capture.assert_called_once_with(error)
+
+    @pytest.mark.anyio
+    async def test_none_error_logged_as_warning(self, mocker):
+        bot = _make_bot(mocker)
+        mock_logger = mocker.patch('bot.adapters.telegram.bot.logger')
+        capture = mocker.patch('bot.adapters.telegram.bot.sentry_sdk.capture_exception')
+        context = mocker.MagicMock()
+        context.error = None
+
+        await bot._handle_error(object(), context)
+
+        mock_logger.warning.assert_called_once_with('telegram_error_missing')
+        mock_logger.exception.assert_not_called()
+        capture.assert_not_called()

--- a/tests/unit/adapters/telegram/test_bot.py
+++ b/tests/unit/adapters/telegram/test_bot.py
@@ -1,7 +1,8 @@
+import logging
 from typing import Any, cast
 
 import pytest
-from telegram.error import TelegramError
+from telegram.error import NetworkError, TelegramError
 
 from bot.adapters.telegram.bot import TelegramBot
 from bot.domain.commands.base import CommandScope, Platform
@@ -81,6 +82,37 @@ class TestStartStop:
         cast('Any', bot._app.initialize).assert_called_once()
         cast('Any', bot._app.start).assert_called_once()
         cast('Any', updater_mock.start_polling).assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_start_registers_error_handler(self, mocker):
+        bot = _make_bot(mocker)
+        bot._app.initialize = mocker.AsyncMock()
+        bot._app.start = mocker.AsyncMock()
+        bot._app.updater = None
+        bot._publish_command_menu = mocker.AsyncMock()
+        _patch_registry(mocker, [])
+
+        await bot.start()
+
+        cast('Any', bot._app.add_error_handler).assert_called_once_with(bot._handle_error)
+
+    @pytest.mark.anyio
+    async def test_start_suppresses_updater_logger(self, mocker):
+        updater_logger = logging.getLogger('telegram.ext.Updater')
+        original_level = updater_logger.level
+        bot = _make_bot(mocker)
+        bot._app.initialize = mocker.AsyncMock()
+        bot._app.start = mocker.AsyncMock()
+        bot._app.updater = None
+        bot._publish_command_menu = mocker.AsyncMock()
+        _patch_registry(mocker, [])
+
+        try:
+            await bot.start()
+
+            assert updater_logger.level == logging.CRITICAL
+        finally:
+            updater_logger.setLevel(original_level or logging.NOTSET)
 
     @pytest.mark.anyio
     async def test_start_without_updater_skips_polling(self, mocker):
@@ -272,3 +304,54 @@ class TestPublishCommandMenu:
         assert len(nsfw_calls) == 2
         published_names = {c.command for c in nsfw_calls[0].args[0]}
         assert published_names == {'oi', 'hentai'}
+
+
+class TestErrorHandler:
+    @pytest.mark.anyio
+    async def test_network_error_logged_as_warning(self, mocker):
+        bot = _make_bot(mocker)
+        mock_logger = mocker.patch('bot.adapters.telegram.bot.logger')
+        context = mocker.MagicMock()
+        context.error = NetworkError('[Errno -3] Try again')
+
+        await bot._handle_error(object(), context)
+
+        mock_logger.warning.assert_called_once_with(
+            'telegram_network_error',
+            error='[Errno -3] Try again',
+        )
+        mock_logger.exception.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_non_network_error_logged_and_captured(self, mocker):
+        bot = _make_bot(mocker)
+        mock_logger = mocker.patch('bot.adapters.telegram.bot.logger')
+        capture = mocker.patch('bot.adapters.telegram.bot.sentry_sdk.capture_exception')
+        context = mocker.MagicMock()
+        error = TelegramError('something broke')
+        context.error = error
+
+        await bot._handle_error(object(), context)
+
+        mock_logger.exception.assert_called_once_with(
+            'telegram_unexpected_error',
+            error='something broke',
+        )
+        capture.assert_called_once_with(error)
+
+    @pytest.mark.anyio
+    async def test_unexpected_exception_logged_and_captured(self, mocker):
+        bot = _make_bot(mocker)
+        mock_logger = mocker.patch('bot.adapters.telegram.bot.logger')
+        capture = mocker.patch('bot.adapters.telegram.bot.sentry_sdk.capture_exception')
+        context = mocker.MagicMock()
+        error = RuntimeError('oops')
+        context.error = error
+
+        await bot._handle_error(object(), context)
+
+        mock_logger.exception.assert_called_once_with(
+            'telegram_unexpected_error',
+            error='oops',
+        )
+        capture.assert_called_once_with(error)

--- a/uv.lock
+++ b/uv.lock
@@ -1838,8 +1838,8 @@ wheels = [
 
 [[package]]
 name = "resenhazord2-core"
-version = "0.1.0"
-source = { virtual = "." }
+version = "1.5.2"
+source = { editable = "." }
 dependencies = [
     { name = "beanie" },
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Release: develop → main

Merge `develop` into `main` for deployment and semantic-release.

### Conventional Commits included (since last release)

- `fix(ci): fix PSR version bump, add automated back-merge and deployment registration`
- `fix(telegram): handle NetworkError gracefully, suppress Updater logger spam`
- `fix(telegram): address review findings for error handler`
- `chore: update uv.lock`

### Merge strategy

**Create a merge commit** — NOT squash, NOT rebase. Required for semantic-release to correctly compute the next version bump from individual Conventional Commits.