### PR TITLE
fix(ci): use correct commitizen version_files pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ logrotate = "docker compose logs --no-color --tail=0 > /dev/null && truncate -s 
 name = "cz_conventional_commits"
 version = "1.5.6"
 tag_format = "v$version"
-version_files = ["pyproject.toml:project.version"]
+version_files = ["pyproject.toml:version"]
 changelog_file = "CHANGELOG.md"
 update_changelog_on_bump = true
 


### PR DESCRIPTION
commitizen cannot match `project.version` in TOML because the line is just `version = ...`. Use `pyproject.toml:version` so the bump correctly updates both project and commitizen versions.