### PR TITLE
fix(ci): use RELEASE_TOKEN for back-merge push

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -202,7 +202,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
       - name: Merge main into develop
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
GITHUB_TOKEN cannot push to protected branches. Use RELEASE_TOKEN so the automated back-merge into develop succeeds.