### PR TITLE
fix(command): make grupo command group names case-insensitive

### DIFF
--- a/bot/domain/commands/group_mentions.py
+++ b/bot/domain/commands/group_mentions.py
@@ -66,7 +66,7 @@ class GroupMentionsCommand(Command):
         return None
 
     async def _handle_create(self, data: CommandData, rest: str) -> list[BotMessage]:
-        group_name = self.MENTION_PATTERN.sub('', rest)
+        group_name = self.MENTION_PATTERN.sub('', rest).lower()
         if not group_name:
             return [Reply.to(data).text(_MISSING_NAME)]
         error = self._validate_group_name(data, group_name)
@@ -84,7 +84,7 @@ class GroupMentionsCommand(Command):
         if not re.match(r'\S+\s+\S+', rest):
             return [Reply.to(data).text('Cadê os nomes dos grupos? 🤔')]
         parts = rest.split()
-        old_name, new_name = parts[0], parts[1]
+        old_name, new_name = parts[0].lower(), parts[1].lower()
         error = self._validate_group_name(data, new_name)
         if error:
             return [error]
@@ -97,34 +97,36 @@ class GroupMentionsCommand(Command):
         return [Reply.to(data).text(f'Grupo *{old}* renomeado para *{new}* com sucesso! 🎉')]
 
     async def _handle_delete(self, data: CommandData, rest: str) -> list[BotMessage]:
-        if not rest:
+        group_name = rest.lower()
+        if not group_name:
             return [Reply.to(data).text(_MISSING_NAME)]
-        result = await self._service.delete(data.jid, rest)
+        result = await self._service.delete(data.jid, group_name)
         if not result['ok']:
             return [Reply.to(data).text(result['message'])]
         return [Reply.to(data).text(f'Grupo *{result["group_name"]}* deletado com sucesso! 🎉')]
 
     async def _handle_list(self, data: CommandData, rest: str) -> list[BotMessage]:
-        if not rest:
+        group_name = rest.lower()
+        if not group_name:
             result = await self._service.list_all(data.jid)
             if not result['ok']:
                 return [Reply.to(data).text(result['message'])]
             lines = [f'- _{g["name"]}_' for g in result['groups']]
             return [Reply.to(data).text('📜 *GRUPOS* 📜\n\n' + '\n'.join(lines))]
 
-        result = await self._service.list_one(data.jid, rest)
+        result = await self._service.list_one(data.jid, group_name)
         if not result['ok']:
             return [Reply.to(data).text(result['message'])]
         lines = [f'- {i + 1}: @{strip_jid(p)}' for i, p in enumerate(result['participants'])]
         return [
             Reply.to(data).text_with(
-                f'📜 *{rest.upper()}* 📜\n\n' + '\n'.join(lines),
+                f'📜 *{group_name.upper()}* 📜\n\n' + '\n'.join(lines),
                 result['participants'],
             )
         ]
 
     async def _handle_add(self, data: CommandData, rest: str) -> list[BotMessage]:
-        group_name = self.MENTION_PATTERN.sub('', rest)
+        group_name = self.MENTION_PATTERN.sub('', rest).lower()
         if not group_name:
             return [Reply.to(data).text(_MISSING_NAME)]
 
@@ -139,7 +141,7 @@ class GroupMentionsCommand(Command):
 
     async def _handle_exit(self, data: CommandData, rest: str) -> list[BotMessage]:
         parts = rest.split()
-        group_name = parts[0] if parts else ''
+        group_name = parts[0].lower() if parts else ''
         if not group_name:
             return [Reply.to(data).text(_MISSING_NAME)]
         indices = [int(p) for p in parts[1:] if p.isdigit()]
@@ -155,7 +157,7 @@ class GroupMentionsCommand(Command):
 
     async def _handle_mention(self, data: CommandData, rest: str) -> list[BotMessage]:
         parts = rest.split(maxsplit=1)
-        group_name = parts[0] if parts else ''
+        group_name = parts[0].lower() if parts else ''
         if not group_name:
             return [Reply.to(data).text(_MISSING_NAME)]
         text = parts[1] if len(parts) > 1 else ''

--- a/tests/unit/commands/test_group_mentions.py
+++ b/tests/unit/commands/test_group_mentions.py
@@ -346,6 +346,102 @@ class TestMention:
         assert 'Não existe' in messages[0].content.text
 
 
+class TestCaseInsensitive:
+    @pytest.mark.anyio
+    async def test_mention_lowercases_group_name(self, command, mock_service):
+        mock_service.mention.return_value = {'ok': True, 'participants': []}
+        data = GroupCommandDataFactory.build(text=',grupo DEVS', jid=CHAT_JID)
+
+        await command.run(data)
+
+        mock_service.mention.assert_called_once_with(CHAT_JID, 'devs')
+
+    @pytest.mark.anyio
+    async def test_create_lowercases_group_name(self, command, mock_service):
+        mock_service.create.return_value = {'ok': True, 'group_name': 'devs'}
+        data = GroupCommandDataFactory.build(
+            text=',grupo create DEVS',
+            jid=CHAT_JID,
+            sender_jid=SENDER_JID,
+        )
+
+        await command.run(data)
+
+        mock_service.create.assert_called_once_with(CHAT_JID, SENDER_JID, 'devs', [])
+
+    @pytest.mark.anyio
+    async def test_add_lowercases_group_name(self, command, mock_service):
+        mock_service.add.return_value = {
+            'ok': True,
+            'group_name': 'devs',
+            'self_only': True,
+        }
+        data = GroupCommandDataFactory.build(
+            text=',grupo add DEVS',
+            jid=CHAT_JID,
+            sender_jid=SENDER_JID,
+        )
+
+        await command.run(data)
+
+        mock_service.add.assert_called_once_with(CHAT_JID, 'devs', SENDER_JID, [])
+
+    @pytest.mark.anyio
+    async def test_delete_lowercases_group_name(self, command, mock_service):
+        mock_service.delete.return_value = {'ok': True, 'group_name': 'devs'}
+        data = GroupCommandDataFactory.build(text=',grupo delete DEVS', jid=CHAT_JID)
+
+        await command.run(data)
+
+        mock_service.delete.assert_called_once_with(CHAT_JID, 'devs')
+
+    @pytest.mark.anyio
+    async def test_list_one_lowercases_group_name(self, command, mock_service):
+        mock_service.list_one.return_value = {
+            'ok': True,
+            'name': 'devs',
+            'participants': [],
+        }
+        data = GroupCommandDataFactory.build(text=',grupo list DEVS', jid=CHAT_JID)
+
+        await command.run(data)
+
+        mock_service.list_one.assert_called_once_with(CHAT_JID, 'devs')
+
+    @pytest.mark.anyio
+    async def test_exit_lowercases_group_name(self, command, mock_service):
+        mock_service.exit.return_value = {
+            'ok': True,
+            'group_name': 'devs',
+            'self_only': True,
+        }
+        data = GroupCommandDataFactory.build(
+            text=',grupo exit DEVS',
+            jid=CHAT_JID,
+            sender_jid=SENDER_JID,
+        )
+
+        await command.run(data)
+
+        mock_service.exit.assert_called_once_with(CHAT_JID, 'devs', SENDER_JID, [])
+
+    @pytest.mark.anyio
+    async def test_rename_lowercases_group_names(self, command, mock_service):
+        mock_service.rename.return_value = {
+            'ok': True,
+            'old_name': 'devs',
+            'new_name': 'eng',
+        }
+        data = GroupCommandDataFactory.build(
+            text=',grupo rename DEVS ENG',
+            jid=CHAT_JID,
+        )
+
+        await command.run(data)
+
+        mock_service.rename.assert_called_once_with(CHAT_JID, 'devs', 'eng')
+
+
 class TestStripJid:
     @pytest.mark.parametrize(
         ('jid', 'expected'),

--- a/uv.lock
+++ b/uv.lock
@@ -1933,7 +1933,7 @@ wheels = [
 
 [[package]]
 name = "resenhazord2-core"
-version = "1.5.6"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "beanie" },


### PR DESCRIPTION
## Summary

- Lowercases group names in the `grupo` command before passing them to the service layer, making all operations (create, add, exit, delete, rename, list, mention) case-insensitive.
- Adds tests covering every handler to verify case normalization.

## Changes

- `bot/domain/commands/group_mentions.py`: normalize extracted group names with `.lower()`
- `tests/unit/commands/test_group_mentions.py`: add `TestCaseInsensitive` with 7 focused tests

## Verification

- All 2423 Python tests pass
- Quality gate (`uv run task check:py`) is green
- Complexity gate (`uv run task complexity`) is green