### PR TITLE
fix(ci): open PR instead of pushing directly to develop on back-merge

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -198,15 +198,27 @@ jobs:
     needs: tag
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
-      - name: Merge main into develop
+      - name: Create back-merge pull request
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout develop
           git merge --no-ff origin/main -m "chore: back-merge main into develop"
-          git push origin develop
+          BACKMERGE_BRANCH="backmerge/main-to-develop-$(date +%s)"
+          git checkout -b "$BACKMERGE_BRANCH"
+          git push origin "$BACKMERGE_BRANCH"
+          gh pr create \
+            --base develop \
+            --head "$BACKMERGE_BRANCH" \
+            --title "chore: back-merge main into develop" \
+            --body "Automated back-merge of \`main\` into \`develop\` after release." \
+            --label "chore" \
+            --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
The back-merge job in the Pipeline workflow was failing because it tried to push directly to the protected `develop` branch. This change creates a temporary back-merge branch and opens a pull request, respecting branch protection rules.