### PR TITLE
feat(gateway): route messages from all chats

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ RESENHA_JID=0000000000000-0000000000@g.us
 RESENHA_TEST_LID=0000000000000@g.us
 RESENHAZORD2_JID=0000000000000@s.whatsapp.net
 RESENHAZORD2_LID=1234567890
+DEV_JID=0000000000000@s.whatsapp.net
+DEV_LID=1234567890
 
 MONGODB_URI='mongodb+srv://<username>:<password>@<clustername>.mongodb.net/<dbname>?retryWrites=true&w=majority'
 MONGODB_DB_NAME=resenhazord2

--- a/gateway/src/events/MessageUpsertEvent.ts
+++ b/gateway/src/events/MessageUpsertEvent.ts
@@ -4,11 +4,6 @@ import CommandHandler from '../handlers/CommandHandler.js';
 export default class MessageUpsertEvent {
   static async run(data: BaileysEventMap['messages.upsert']): Promise<void> {
     const [message] = data.messages;
-    const { RESENHA_JID, RESENHAZORD2_JID, RESENHA_TEST_LID } = process.env;
-    const chat = message.key.remoteJid;
-    if (!chat || ![RESENHA_JID, RESENHAZORD2_JID, RESENHA_TEST_LID].includes(chat)) {
-      return;
-    }
     if (process.env.DEBUG === 'true' && data.type !== 'notify') {
       return;
     }

--- a/uv.lock
+++ b/uv.lock
@@ -1933,7 +1933,7 @@ wheels = [
 
 [[package]]
 name = "resenhazord2-core"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "beanie" },


### PR DESCRIPTION
## Why

A dedicated bot number replaced the personal test number. The chat-whitelist guard in `MessageUpsertEvent` (`RESENHA_JID`, `RESENHAZORD2_JID`, `RESENHA_TEST_LID`) existed only to stop the personal test number from spamming real chats. With a dedicated number it serves no purpose and blocks legitimate traffic.

## What

- Remove the chat-whitelist `if` guard in `MessageUpsertEvent` — every incoming chat now reaches `CommandHandler`. The `DEBUG`/`notify` guard stays.
- Document `DEV_JID`/`DEV_LID` (former personal test identity) in `.env.example`.
- `uv.lock` syncs to the already-released `1.6.1`.

## Deploy note

VPS `.env` already updated with the new number's `RESENHAZORD2_JID`/`RESENHAZORD2_LID`. Production deploy follows via the release PR `develop → main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)