### PR TITLE
fix(dl): map unmapped yt-dlp error messages

### DIFF
--- a/bot/data/download_errors.py
+++ b/bot/data/download_errors.py
@@ -2,6 +2,9 @@ FILE_TOO_LARGE_MESSAGE = 'Vídeo muito grande pra baixar 📦'
 
 YTDLP_ERROR_MESSAGES: dict[str, str] = {
     'There is no video in this post': 'Esse post não tem vídeo 📸',
+    'No video could be found in this tweet': 'Esse tweet não tem vídeo 📸',
+    'Unsupported URL': 'Esse link não é suportado 🔗',
+    'login required': 'Esse conteúdo precisa de login 🔐',
     'Video unavailable': 'Esse vídeo não está disponível 😔',
     'Private video': 'Esse vídeo é privado 🔒',
     'Sign in to confirm your age': 'Esse vídeo tem restrição de idade 🔞',

--- a/tests/unit/commands/test_download.py
+++ b/tests/unit/commands/test_download.py
@@ -195,6 +195,58 @@ class TestErrors:
         assert 'bloqueado' in exc_info.value.user_message
 
     @pytest.mark.anyio
+    async def test_no_video_in_tweet(self, command, mock_subprocess):
+        data = GroupCommandDataFactory.build(text=',dl https://x.com/user/status/123')
+        mock_subprocess(
+            'bot.domain.services.ytdlp.asyncio.create_subprocess_exec',
+            calls=[
+                (b'Title\n', b'', 0),
+                (b'', b'ERROR: [twitter] 123: No video could be found in this tweet', 1),
+            ],
+        )
+
+        with pytest.raises(DownloadError) as exc_info:
+            await command.run(data)
+
+        assert 'não tem vídeo' in exc_info.value.user_message
+
+    @pytest.mark.anyio
+    async def test_unsupported_url(self, command, mock_subprocess):
+        data = GroupCommandDataFactory.build(text=',dl https://example.com/unknown')
+        mock_subprocess(
+            'bot.domain.services.ytdlp.asyncio.create_subprocess_exec',
+            calls=[
+                (b'Title\n', b'', 0),
+                (b'', b'ERROR: Unsupported URL: https://example.com/unknown', 1),
+            ],
+        )
+
+        with pytest.raises(DownloadError) as exc_info:
+            await command.run(data)
+
+        assert 'não é suportado' in exc_info.value.user_message
+
+    @pytest.mark.anyio
+    async def test_login_required(self, command, mock_subprocess):
+        data = GroupCommandDataFactory.build(text=',dl https://instagram.com/reel/abc')
+        mock_subprocess(
+            'bot.domain.services.ytdlp.asyncio.create_subprocess_exec',
+            calls=[
+                (b'Title\n', b'', 0),
+                (
+                    b'',
+                    b'ERROR: [Instagram] abc: login required',
+                    1,
+                ),
+            ],
+        )
+
+        with pytest.raises(DownloadError) as exc_info:
+            await command.run(data)
+
+        assert 'precisa de login' in exc_info.value.user_message
+
+    @pytest.mark.anyio
     async def test_subprocess_exception(self, command, mocker):
         data = GroupCommandDataFactory.build(text=',dl https://youtube.com/watch?v=abc')
         mocker.patch(


### PR DESCRIPTION
## Summary

- Map Twitter/X error "No video could be found in this tweet" to user-friendly message
- Map "Unsupported URL" error to inform users the link isn't supported
- Map "login required" error for Instagram rate-limited content

## Type

- [x] `fix` — bug fix

## Test plan

- [x] 3 new unit tests covering each new error mapping
- [x] Full test suite passes (2429 passed, 0 failures)
- [x] Probed failing URLs with yt-dlp to confirm error messages match

## Target branch

This PR targets `develop` (default).