### PR TITLE
fix(dl): fix video delivery for multi-video tweets and view-once

### DIFF
--- a/bot/domain/services/ytdlp.py
+++ b/bot/domain/services/ytdlp.py
@@ -10,6 +10,8 @@ class YtDlpService:
     async def download(cls, url: str) -> tuple[bytes, str]:
         title_proc = await asyncio.create_subprocess_exec(
             'yt-dlp',
+            '--playlist-items',
+            '1',
             '--print',
             'title',
             url,
@@ -21,6 +23,8 @@ class YtDlpService:
 
         video_proc = await asyncio.create_subprocess_exec(
             'yt-dlp',
+            '--playlist-items',
+            '1',
             '-f',
             'best[ext=mp4]/best',
             '--max-filesize',

--- a/gateway/src/bridge/PythonBridge.ts
+++ b/gateway/src/bridge/PythonBridge.ts
@@ -369,7 +369,7 @@ export default class PythonBridge {
       }),
       video_buffer: (cd, cap) => ({
         video: takeBuffer(),
-        viewOnce: cd.view_once as boolean,
+        viewOnce: false,
         gifPlayback: (cd.gif_playback as boolean) ?? false,
         caption: cap,
       }),

--- a/tests/unit/commands/test_download.py
+++ b/tests/unit/commands/test_download.py
@@ -82,6 +82,23 @@ class TestRun:
         assert 'https://tiktok.com/@user/video/123' in first_call_args
 
     @pytest.mark.anyio
+    async def test_limits_to_single_playlist_item(self, command, mock_subprocess):
+        data = GroupCommandDataFactory.build(text=',dl https://x.com/i/status/123')
+        mock_exec = mock_subprocess(
+            'bot.domain.services.ytdlp.asyncio.create_subprocess_exec',
+            calls=[
+                (b'Title\n', b'', 0),
+                (b'video-data', b'', 0),
+            ],
+        )
+
+        await command.run(data)
+
+        for call in mock_exec.call_args_list:
+            assert '--playlist-items' in call[0]
+            assert '1' in call[0]
+
+    @pytest.mark.anyio
     async def test_empty_title_defaults_to_video(self, command, mock_subprocess):
         data = GroupCommandDataFactory.build(text=',dl https://example.com/v')
         mock_subprocess(


### PR DESCRIPTION
## Summary

- Limit yt-dlp to single playlist item to prevent multi-video tweets from corrupting the output
- Disable view-once for video_buffer on WhatsApp — Baileys silently drops view-once videos from in-memory buffers

## Type

- [x] `fix` — bug fix

## Test plan

- [x] Unit test for --playlist-items flag
- [x] Full test suite passes (2431 passed)
- [x] Manual test: `,dl https://x.com/i/status/2060428693688778779` now delivers video on WhatsApp

## Target branch

This PR targets `develop` (default).