### PR TITLE
feat(command): add pop ranking option to myanimelist

### DIFF
--- a/bot/domain/commands/my_anime_list.py
+++ b/bot/domain/commands/my_anime_list.py
@@ -66,9 +66,7 @@ class MyAnimeListCommand(Command):
         if pop_mode:
             params['filter'] = 'bypopularity'
 
-        response = await HttpClient.get(
-            f'https://api.jikan.moe/v4/top/{media_type}', params=params
-        )
+        response = await HttpClient.get(f'https://api.jikan.moe/v4/top/{media_type}', params=params)
         response.raise_for_status()
         items = response.json()['data']
 

--- a/bot/domain/commands/my_anime_list.py
+++ b/bot/domain/commands/my_anime_list.py
@@ -44,22 +44,30 @@ class MyAnimeListCommand(Command):
             name='anime',
             aliases=['manga'],
             flags=[Flag.SHOW, Flag.DM],
-            options=[OptionDef(name='top', pattern=r'top\d+')],
+            options=[
+                OptionDef(name='pop', pattern=r'pop\d*'),
+                OptionDef(name='top', pattern=r'top\d+'),
+            ],
             category=Category.RANDOM,
             platforms=[Platform.ALL],
         )
 
     @property
     def menu_description(self) -> str:
-        return 'Receba um anime ou mangá aleatório. Use top<N> para limitar o ranking.'
+        return 'Receba um anime ou mangá aleatório. Use top<N> ou pop<N> para limitar o ranking.'
 
     async def execute(self, data: CommandData, parsed: ParsedCommand) -> list[BotMessage]:
         media_type = 'anime' if parsed.command_name == 'anime' else 'manga'
+        pop_mode = 'pop' in parsed.options
         top_n, max_page = self._resolve_page_range(parsed)
 
         page = random.randint(1, max_page)  # noqa: S311
+        params: dict[str, str | int] = {'page': page}
+        if pop_mode:
+            params['filter'] = 'bypopularity'
+
         response = await HttpClient.get(
-            f'https://api.jikan.moe/v4/top/{media_type}', params={'page': page}
+            f'https://api.jikan.moe/v4/top/{media_type}', params=params
         )
         response.raise_for_status()
         items = response.json()['data']
@@ -74,12 +82,21 @@ class MyAnimeListCommand(Command):
         return [Reply.to(data).image(image, caption)]
 
     def _resolve_page_range(self, parsed: ParsedCommand) -> tuple[int, int]:
+        if 'pop' in parsed.options:
+            pop_str = parsed.options['pop']
+            pop_n = pop_str.removeprefix('pop')
+            if pop_n:
+                rank_limit = int(pop_n)
+                return rank_limit, max(
+                    1, (rank_limit + self.ITEMS_PER_PAGE - 1) // self.ITEMS_PER_PAGE
+                )
+            return 0, self.DEFAULT_MAX_PAGE
+
         top_str = parsed.options.get('top', '')
         if not top_str:
             return 0, self.DEFAULT_MAX_PAGE
-        top_n = int(top_str[3:])
-        max_page = max(1, (top_n + self.ITEMS_PER_PAGE - 1) // self.ITEMS_PER_PAGE)
-        return top_n, max_page
+        top_n = int(top_str.removeprefix('top'))
+        return top_n, max(1, (top_n + self.ITEMS_PER_PAGE - 1) // self.ITEMS_PER_PAGE)
 
     @classmethod
     def _build_caption(cls, item: dict, profile: dict) -> str:

--- a/tests/unit/commands/test_my_anime_list.py
+++ b/tests/unit/commands/test_my_anime_list.py
@@ -57,6 +57,9 @@ class TestMatches:
             (', anime top100', True),
             (', anime top50', True),
             (', manga top250', True),
+            (', anime pop', True),
+            (', anime pop100', True),
+            (', manga pop', True),
             ('anime', False),
             ('hello', False),
             (', anime extra', False),
@@ -149,3 +152,55 @@ class TestRun:
         await command.run(data)
 
         mock_randint.assert_called_once_with(1, 20)
+
+    @pytest.mark.anyio
+    async def test_pop_uses_bypopularity_filter(self, command, respx_mock):
+        data = GroupCommandDataFactory.build(text=', anime pop')
+        route = respx_mock.get(url__regex=r'.*/top/anime.*').mock(
+            return_value=httpx.Response(200, json={'data': [_anime_item()]})
+        )
+
+        await command.run(data)
+
+        url = str(route.calls.last.request.url)
+        assert 'filter=bypopularity' in url
+
+    @pytest.mark.anyio
+    async def test_pop100_limits_page_range(self, command, respx_mock, mocker):
+        data = GroupCommandDataFactory.build(text=', anime pop100')
+        respx_mock.get(url__regex=r'.*/top/anime.*').mock(
+            return_value=httpx.Response(200, json={'data': [_anime_item()]})
+        )
+        mock_randint = mocker.patch(
+            'bot.domain.commands.my_anime_list.random.randint', return_value=1
+        )
+
+        await command.run(data)
+
+        mock_randint.assert_called_once_with(1, 4)
+
+    @pytest.mark.anyio
+    async def test_pop_without_number_uses_full_range(self, command, respx_mock, mocker):
+        data = GroupCommandDataFactory.build(text=', anime pop')
+        respx_mock.get(url__regex=r'.*/top/anime.*').mock(
+            return_value=httpx.Response(200, json={'data': [_anime_item()]})
+        )
+        mock_randint = mocker.patch(
+            'bot.domain.commands.my_anime_list.random.randint', return_value=1
+        )
+
+        await command.run(data)
+
+        mock_randint.assert_called_once_with(1, 20)
+
+    @pytest.mark.anyio
+    async def test_pop_manga_uses_bypopularity_filter(self, command, respx_mock):
+        data = GroupCommandDataFactory.build(text=', manga pop')
+        route = respx_mock.get(url__regex=r'.*/top/manga.*').mock(
+            return_value=httpx.Response(200, json={'data': [_manga_item()]})
+        )
+
+        await command.run(data)
+
+        url = str(route.calls.last.request.url)
+        assert 'filter=bypopularity' in url


### PR DESCRIPTION
## Summary

- Add `pop` and `pop<N>` options to the anime/manga command for popularity-based ranking
- Uses Jikan API `filter=bypopularity` parameter (different ordering than default top by score)
- Follows same pattern as movie_series command's pop option

## Type

- [x] `feat` — new feature
- [x] `test` — add/update tests

## Test plan

- [x] Unit tests: 36 tests pass (`pytest tests/unit/commands/test_my_anime_list.py`)
- [x] Probe script confirms API returns correct data (`scripts/probe_mal_pop.py`)
- [x] Linter clean (`ruff check`)
- [x] Tested: `, anime pop` (all popular), `, anime pop100` (top 100 popular), `, manga pop`

## Target branch

This PR targets `develop` (default).