### PR TITLE
test: kill surviving mutants in borges, fact, quran, mateus, fuck

### DIFF
--- a/tests/unit/commands/test_borges.py
+++ b/tests/unit/commands/test_borges.py
@@ -65,3 +65,16 @@ class TestRun:
         messages = await command.run(data)
 
         assert '1 nargas' in messages[0].content.text
+
+    @pytest.mark.anyio
+    async def test_uses_borges_collection(self, command, mock_collection, mocker):
+        mock_collection.find_one_and_update.return_value = {'nargas': 1}
+        data = GroupCommandDataFactory.build(text=',borges')
+        collection_spy = mocker.patch(
+            'bot.infrastructure.mongodb.MongoDBConnection.collection',
+            return_value=mock_collection,
+        )
+
+        await command.run(data)
+
+        collection_spy.assert_called_once_with('borges')

--- a/tests/unit/commands/test_fact.py
+++ b/tests/unit/commands/test_fact.py
@@ -97,3 +97,18 @@ class TestRun:
         messages = await command.run(data)
 
         assert messages[0].expiration == 86400
+
+    @pytest.mark.anyio
+    async def test_translator_receives_fact_text(self, command, respx_mock):
+        data = GroupCommandDataFactory.build(text=', fato')
+        respx_mock.get(self.RANDOM_URL).mock(
+            return_value=httpx.Response(200, json={'text': 'Cats sleep 70%.'})
+        )
+        translate_route = respx_mock.get(
+            url__startswith='https://translate.googleapis.com/translate_a/single'
+        ).mock(return_value=httpx.Response(200, json=[[['Traduzido', 'original']]]))
+
+        await command.run(data)
+
+        request_url = str(translate_route.calls.last.request.url)
+        assert 'Cats' in request_url

--- a/tests/unit/commands/test_fuck.py
+++ b/tests/unit/commands/test_fuck.py
@@ -109,3 +109,43 @@ class TestRun:
 
         content = messages[0].content.content
         assert sender in content['mentions']
+
+    @pytest.mark.anyio
+    async def test_empty_mentioned_when_no_jids(self, command, respx_mock):
+        sender = '5511999990001@s.whatsapp.net'
+        data = GroupCommandDataFactory.build(
+            text=', fuck @123',
+            sender_jid=sender,
+            participant=sender,
+            mentioned_jids=[],
+        )
+
+        respx_mock.get(self.URL).mock(
+            return_value=httpx.Response(
+                200, json={'image': {'url': 'https://example.com/video.mp4'}}
+            )
+        )
+        messages = await command.run(data)
+
+        content = messages[0].content.content
+        assert '@' in content['caption']
+        assert '' in content['mentions']
+
+    @pytest.mark.anyio
+    async def test_api_called_with_timeout(self, command, respx_mock):
+        sender = '5511999990001@s.whatsapp.net'
+        data = GroupCommandDataFactory.build(
+            text=', fuck @123',
+            sender_jid=sender,
+            participant=sender,
+            mentioned_jids=['123@s.whatsapp.net'],
+        )
+        route = respx_mock.get(self.URL).mock(
+            return_value=httpx.Response(
+                200, json={'image': {'url': 'https://example.com/video.mp4'}}
+            )
+        )
+
+        await command.run(data)
+
+        assert route.calls.last.request.extensions.get('timeout', {}).get('read') == 30.0

--- a/tests/unit/commands/test_fuck.py
+++ b/tests/unit/commands/test_fuck.py
@@ -148,4 +148,5 @@ class TestRun:
 
         await command.run(data)
 
-        assert route.calls.last.request.extensions.get('timeout', {}).get('read') == 30.0
+        timeout = route.calls.last.request.extensions.get('timeout', {})
+        assert timeout.get('read') == pytest.approx(30.0)

--- a/tests/unit/commands/test_mateus.py
+++ b/tests/unit/commands/test_mateus.py
@@ -57,3 +57,12 @@ class TestRun:
         messages = await command.run(data)
 
         assert messages[0].expiration == 86400
+
+    @pytest.mark.anyio
+    async def test_exact_threshold_uses_correct_tier(self, command, mocker):
+        mocker.patch('bot.domain.commands.mateus.random.uniform', return_value=100.0)
+        data = GroupCommandDataFactory.build(text=', mateus')
+
+        messages = await command.run(data)
+
+        assert 'JÁ ESTÁ AQUI' in messages[0].content.text

--- a/tests/unit/commands/test_quran.py
+++ b/tests/unit/commands/test_quran.py
@@ -125,3 +125,15 @@ class TestRun:
         messages = await command.run(data)
 
         assert messages[0].expiration == 86400
+
+    @pytest.mark.anyio
+    async def test_randint_called_with_1_and_total_ayahs(self, command, respx_mock, mocker):
+        data = GroupCommandDataFactory.build(text=', alcorão')
+        mock_randint = mocker.patch('bot.domain.commands.quran.random.randint', return_value=42)
+        respx_mock.get(url__startswith='https://api.alquran.cloud/v1/ayah/').mock(
+            return_value=httpx.Response(200, json=MOCK_EDITIONS)
+        )
+
+        await command.run(data)
+
+        mock_randint.assert_called_once_with(1, 6236)


### PR DESCRIPTION
## Summary

- Add tests to kill surviving mutants in 5 command files
- 5 new tests targeting 10 mutations

## Type

- [x] `test` — add/update tests

## Test plan

- [x] All 2458 tests pass
- [x] Pre-commit hooks pass

## Mutants killed

| File | Mutants | Fix |
|------|---------|-----|
| borges.py | 2 | Verify `collection("borges")` called |
| fact.py | 14 | Verify translator receives fact text |
| quran.py | 1, 6 | Assert `randint(1, 6236)` |
| mateus.py | 15 | Test exact threshold boundary (`>=` vs `>`) |
| fuck.py | 7, 12, 14, 17 | Test empty mentions fallback + timeout=30.0 |

## Target branch

This PR targets `develop` (default).