### PR TITLE
chore: back-merge main into develop

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -86,40 +86,11 @@ jobs:
           flags: python
           files: coverage.xml
 
-  mutation-py:
-    name: Python mutation testing
-    runs-on: ubuntu-latest
-    needs: test-py
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
-      - run: uv sync --frozen
-      - name: Scope mutation to changed files
-        run: |
-          # Drop paths listed as do_not_mutate in setup.cfg: mutmut skips them, so
-          # scoping to only those yields an empty sandbox that fails the baseline run.
-          EXCLUDE='^bot/(infrastructure|adapters)/|^bot/(main|settings)\.py$|^bot/domain/services/discord\.py$'
-          CHANGED=$(git diff --name-only HEAD~1...HEAD -- 'bot/**.py' | { grep -vE "$EXCLUDE" || true; } | tr '\n' ',')
-          if [ -z "$CHANGED" ]; then
-            echo "No mutable Python files changed in bot/, skipping mutation testing"
-            echo "SKIP_MUTMUT=true" >> "$GITHUB_ENV"
-          else
-            sed -i "s|^paths_to_mutate = .*|paths_to_mutate = ${CHANGED%,}|" setup.cfg
-            echo "Mutating: $CHANGED"
-          fi
-      - run: uv run mutmut run
-        if: env.SKIP_MUTMUT != 'true'
-      - run: uv run mutmut results
-        if: env.SKIP_MUTMUT != 'true'
-
   # Stage 3: Build Docker images (after all tests pass)
   build:
     name: Build and push Docker images
     runs-on: ubuntu-latest
-    needs: [test-ts, test-py, mutation-py]
+    needs: [test-ts, test-py]
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
Automated back-merge of `main` into `develop` after the v1.8.0 release. Brings the deploy-pipeline fix (drop mutation job) onto develop. The original pipeline step failed only because the `chore` label did not exist; the branch was already pushed.