### PR TITLE
ci(pipeline): make back-merge resilient to missing chore label

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -222,6 +222,8 @@ jobs:
           BACKMERGE_BRANCH="backmerge/main-to-develop-$(date +%s)"
           git checkout -b "$BACKMERGE_BRANCH"
           git push origin "$BACKMERGE_BRANCH"
+          # Ensure the label exists, otherwise gh pr create fails the whole release job.
+          gh label create chore --color cfd3d7 --description "Tooling, config, maintenance" 2>/dev/null || true
           gh pr create \
             --base develop \
             --head "$BACKMERGE_BRANCH" \


### PR DESCRIPTION
## Why

The v1.8.0 release back-merge job failed at `gh pr create --label "chore"` because the repo had no `chore` label, even though Build/Deploy/Tag all succeeded. A cosmetic label shouldn't red-flag a successful release.

## Fix

Create the `chore` label idempotently (`gh label create ... 2>/dev/null || true`) right before opening the back-merge PR. The label now exists in the repo too, so this is belt-and-suspenders for fresh clones/forks.