### PR TITLE
fix(deploy): pin container DNS and bound log size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,14 @@ services:
     networks:
       - bot-network
     restart: unless-stopped
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test: ["CMD-SHELL", "pidof bun || exit 1"]
       interval: 30s
@@ -31,6 +39,14 @@ services:
     networks:
       - bot-network
     restart: unless-stopped
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 10s


### PR DESCRIPTION
## Why

The Oracle VPS (1 GB RAM, **no swap**) froze ~hours after each deploy: 100% usage, host unreachable, requiring an out-of-band console reboot. Post-mortem from the surviving container json-logs identified a three-layer cause — **not** the `/ws` disconnect storm fixed in v1.8.0:

| Layer | Finding |
|---|---|
| **Trigger** | VPS DNS resolution intermittently fails (`gaierror -3` / EAI_AGAIN). At 19:51 every outbound client (Mongo SRV, Telegram, Discord, Sentry) failed name resolution simultaneously. |
| **Amplifier** | `LOG_LEVEL=DEBUG` + `DEBUG=true`: each retry emitted ~10 log lines across 4 libraries. Bot json-log = 118 MB/47h vs gateway 56 KB. |
| **Fatal mechanism** | No swap on 954 MB → memory exhaustion → kernel reclaim thrash. Log rate decayed 237/s → 1 line/10–30 min → silence (catatonic, not crashed: restarts=0, oomkilled=false). |

## This PR

- **Pin both containers' DNS** to `1.1.1.1` / `8.8.8.8` so they don't depend on the flaking embedded/host resolver that returned EAI_AGAIN (addresses the trigger).
- **Bound the json-file log driver** (`max-size: 10m`, `max-file: 3`) so logs can't grow unbounded toward the 45 GB disk.

## Already applied directly to prod (ops, not in this diff)

- `.env`: `DEBUG=false`, `LOG_LEVEL=INFO` — cut log volume ~100× (237/s bursts → ~13/min)
- Added a 2 GB swapfile (persisted in fstab, `vm.swappiness=10`) — removes the fatal mechanism
- systemd `vps-sampler.timer` (60s) capturing mem/load/per-container stats — so the next incident is never blind

## Not included (deliberately)

- Container memory limits (previously declined)
- pymongo SRV/retry tuning

🤖 Generated with [Claude Code](https://claude.com/claude-code)