### PR TITLE
release: v1.8.1

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -222,6 +222,8 @@ jobs:
           BACKMERGE_BRANCH="backmerge/main-to-develop-$(date +%s)"
           git checkout -b "$BACKMERGE_BRANCH"
           git push origin "$BACKMERGE_BRANCH"
+          # Ensure the label exists, otherwise gh pr create fails the whole release job.
+          gh label create chore --color cfd3d7 --description "Tooling, config, maintenance" 2>/dev/null || true
           gh pr create \
             --base develop \
             --head "$BACKMERGE_BRANCH" \

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -86,40 +86,11 @@ jobs:
           flags: python
           files: coverage.xml
 
-  mutation-py:
-    name: Python mutation testing
-    runs-on: ubuntu-latest
-    needs: test-py
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
-      - run: uv sync --frozen
-      - name: Scope mutation to changed files
-        run: |
-          # Drop paths listed as do_not_mutate in setup.cfg: mutmut skips them, so
-          # scoping to only those yields an empty sandbox that fails the baseline run.
-          EXCLUDE='^bot/(infrastructure|adapters)/|^bot/(main|settings)\.py$|^bot/domain/services/discord\.py$'
-          CHANGED=$(git diff --name-only HEAD~1...HEAD -- 'bot/**.py' | { grep -vE "$EXCLUDE" || true; } | tr '\n' ',')
-          if [ -z "$CHANGED" ]; then
-            echo "No mutable Python files changed in bot/, skipping mutation testing"
-            echo "SKIP_MUTMUT=true" >> "$GITHUB_ENV"
-          else
-            sed -i "s|^paths_to_mutate = .*|paths_to_mutate = ${CHANGED%,}|" setup.cfg
-            echo "Mutating: $CHANGED"
-          fi
-      - run: uv run mutmut run
-        if: env.SKIP_MUTMUT != 'true'
-      - run: uv run mutmut results
-        if: env.SKIP_MUTMUT != 'true'
-
   # Stage 3: Build Docker images (after all tests pass)
   build:
     name: Build and push Docker images
     runs-on: ubuntu-latest
-    needs: [test-ts, test-py, mutation-py]
+    needs: [test-ts, test-py]
     permissions:
       packages: write
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- version list -->
 
+## v1.8.1 (2026-06-07)
+
+### Fix
+
+- **deploy**: pin container DNS and bound log size
+
 ## v1.8.0 (2026-06-05)
 
 ### Feat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,14 @@ services:
     networks:
       - bot-network
     restart: unless-stopped
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test: ["CMD-SHELL", "pidof bun || exit 1"]
       interval: 30s
@@ -31,6 +39,14 @@ services:
     networks:
       - bot-network
     restart: unless-stopped
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 10s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "resenhazord2-core"
-version = "1.8.0"
+version = "1.8.1"
 description = "Python core for Resenhazord2 WhatsApp bot"
 requires-python = ">=3.13"
 dependencies = [
@@ -75,7 +75,7 @@ exclude = ["tests/"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.8.0"
+version = "1.8.1"
 tag_format = "v$version"
 version_files = ["pyproject.toml:version"]
 changelog_file = "CHANGELOG.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2034,7 +2034,7 @@ wheels = [
 
 [[package]]
 name = "resenhazord2-core"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "beanie" },


### PR DESCRIPTION
# Release PR: `develop` → `main`

> **Merge strategy: "Create a merge commit". Do NOT squash.**

## Highlights

### 🐛 Fixes (`fix`)

- **fix(deploy): pin container DNS and bound log size** (#105) — root-cause fix for the VPS freeze. Pins both containers to public resolvers (1.1.1.1 / 8.8.8.8) so they no longer depend on the flaking embedded/host resolver that returned `EAI_AGAIN`, and caps the json-file log driver (10m × 3) so logs can't grow unbounded.

### Other

- ci(pipeline): drop mutation job from deploy pipeline (#102)
- ci(pipeline): make back-merge resilient to missing chore label (#103)
- chore: back-merge main into develop (#104)

## Deploy impact

- [ ] New env vars / secrets required — **No.** (`DEBUG=false` / `LOG_LEVEL=INFO` were already applied to the prod `.env` as ops; not part of this diff.)
- [ ] Schema / data migrations — **No.**
- [x] Rollback plan: revert the merge commit; `docker compose up -d` restores prior container config.

**Note:** the deploy step (`docker compose up -d`) recreates the containers, applying the new `dns:` and `logging:` config. Already-live ops mitigations (2 GB swap, INFO logging, systemd sampler) remain independent of this deploy.

## Pre-merge checklist

- [x] CI green on develop
- [x] `develop` has no conflicts with `main` (0 behind)
- [x] Highlights match `git log main..develop --oneline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)