### PR TITLE
ci(workflows): namespace uv cache per job and bump github-script to v8

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          cache-suffix: ${{ github.job }}
       - run: uv sync --frozen
       - run: uv run ruff check .
       - run: uv run ruff format --check .
@@ -42,6 +44,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          cache-suffix: ${{ github.job }}
       - run: uv sync --frozen
       - run: uv run bandit -c bandit.toml -r bot/
 
@@ -71,6 +75,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          cache-suffix: ${{ github.job }}
       - run: uv sync --frozen
       - run: uv run pytest -v --cov=bot --cov-report=xml
       - name: Upload coverage to Codecov
@@ -86,6 +92,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          cache-suffix: ${{ github.job }}
       - run: uv sync --frozen
       - run: uv run task complexity
 
@@ -99,6 +107,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          cache-suffix: ${{ github.job }}
       - run: uv sync --frozen
       - name: Scope mutation to changed files
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          cache-suffix: ${{ github.job }}
       - run: uv sync --frozen
       - run: uv run ruff check .
       - run: uv run ruff format --check .
@@ -38,6 +40,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          cache-suffix: ${{ github.job }}
       - run: uv sync --frozen
       - run: uv run bandit -c bandit.toml -r bot/
 
@@ -47,6 +51,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          cache-suffix: ${{ github.job }}
       - run: uv sync --frozen
       - run: uv run task complexity
 
@@ -77,6 +83,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          cache-suffix: ${{ github.job }}
       - run: uv sync --frozen
       - run: uv run pytest -v --cov=bot --cov-report=xml
       - name: Upload coverage to Codecov
@@ -160,7 +168,7 @@ jobs:
     permissions:
       deployments: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           script: |
             const deployment = await github.rest.repos.createDeployment({


### PR DESCRIPTION
Resolves the two non-blocking warnings seen on the v1.8.2 release run.

## 1. setup-uv cache-reserve race
```
Failed to save: Unable to reserve cache with key setup-uv-… another job may be creating this cache.
```
The parallel Python jobs (`lint-py`, `security-py`, `complexity-py`, `test-py`, `mutation-py`) all compute the **same** setup-uv cache key (same `uv.lock` + Python + runner) and race to save it — one wins, the rest warn. Add `cache-suffix: ${{ github.job }}` to every setup-uv step so each job owns a distinct key. Applied in both `pipeline.yml` (4) and `check.yml` (5).

## 2. github-script on deprecated Node 20
```
actions/github-script@v7 … running on Node.js 20 … forced to Node.js 24 by default starting June 16th, 2026.
```
Bump the `register-deploy` job's `actions/github-script@v7` → `@v8` (Node 24). Tag style matches the repo's convention for official `actions/*` (e.g. `actions/checkout@v5`).

No behavior change — caching still works (now per-job), and the deployment-registration script is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)