### PR TITLE
fix(gateway): quote replies with the original message, not a key stub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       context: ./gateway
       dockerfile: Dockerfile
     env_file: .env
+    environment:
+      # Reach the broker by its service name; .env's localhost only works on the host.
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672/
     tty: true
     working_dir: /app
     depends_on:
@@ -40,6 +43,9 @@ services:
       context: .
       dockerfile: Dockerfile
     env_file: .env
+    environment:
+      # Reach the broker by its service name; .env's localhost only works on the host.
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672/
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/gateway/src/bridge/BrokerForwarder.ts
+++ b/gateway/src/bridge/BrokerForwarder.ts
@@ -26,7 +26,9 @@ export default class BrokerForwarder {
 
     try {
       const id = await this.publisher.publish(commandData);
-      this.inFlight.track(id, jid);
+      // Keep the original message in flight so ReplyConsumer can quote it: Baileys
+      // needs the full WAMessage, not just its id, to build the reply context.
+      this.inFlight.track(id, jid, data);
     } catch (error) {
       logger.error({ event: 'command_publish_failed', jid, error: String(error) });
       Sentry.captureException(error);

--- a/gateway/src/bridge/InFlightCommands.ts
+++ b/gateway/src/bridge/InFlightCommands.ts
@@ -1,13 +1,20 @@
-export default class InFlightCommands {
-  private readonly byId = new Map<string, string>();
+import type { WAMessage } from '@whiskeysockets/baileys';
 
-  track(id: string, jid: string): void {
-    this.byId.set(id, jid);
+export interface InFlightCommand {
+  jid: string;
+  quoted: WAMessage;
+}
+
+export default class InFlightCommands {
+  private readonly byId = new Map<string, InFlightCommand>();
+
+  track(id: string, jid: string, quoted: WAMessage): void {
+    this.byId.set(id, { jid, quoted });
   }
 
-  resolve(id: string): string | undefined {
-    const jid = this.byId.get(id);
+  resolve(id: string): InFlightCommand | undefined {
+    const command = this.byId.get(id);
     this.byId.delete(id);
-    return jid;
+    return command;
   }
 }

--- a/gateway/src/bridge/ReplyConsumer.ts
+++ b/gateway/src/bridge/ReplyConsumer.ts
@@ -1,3 +1,4 @@
+import type { MiscMessageGenerationOptions, WAMessage } from '@whiskeysockets/baileys';
 import type BrokerPort from '../ports/BrokerPort.js';
 import type WhatsAppPort from '../ports/WhatsAppPort.js';
 import type InFlightCommands from './InFlightCommands.js';
@@ -28,14 +29,26 @@ export default class ReplyConsumer {
     // Carry the correlation id in the gateway's logs too, so one id spans both
     // processes when tracing a command (§12).
     logger.info({ event: 'reply_received', correlationId: envelope.id });
-    for (const raw of envelope.messages) {
-      const message = await ReplyDeserializer.toMessage(raw);
-      await this.whatsapp.sendMessage(message.jid, message.content, message.options ?? {});
-    }
 
     // The registry carries the jid even for an empty terminal reply (no-output
-    // commands), so the typing indicator always stops.
-    const jid = this.inFlight.resolve(envelope.id);
-    if (jid) await TypingIndicator.stop(jid);
+    // commands), so the typing indicator always stops. It also holds the original
+    // message, which Baileys needs to quote the reply.
+    const command = this.inFlight.resolve(envelope.id);
+    for (const raw of envelope.messages) {
+      const message = await ReplyDeserializer.toMessage(raw);
+      const options = ReplyConsumer.withQuoted(message.options, raw, command?.quoted);
+      await this.whatsapp.sendMessage(message.jid, message.content, options);
+    }
+
+    if (command) await TypingIndicator.stop(command.jid);
+  }
+
+  private static withQuoted(
+    options: MiscMessageGenerationOptions | undefined,
+    raw: Record<string, unknown>,
+    quoted: WAMessage | undefined,
+  ): MiscMessageGenerationOptions {
+    if (raw.quoted_message_id && quoted) return { ...options, quoted };
+    return options ?? {};
   }
 }

--- a/gateway/src/bridge/ReplyDeserializer.ts
+++ b/gateway/src/bridge/ReplyDeserializer.ts
@@ -1,4 +1,4 @@
-import type { AnyMessageContent, WAMessage } from '@whiskeysockets/baileys';
+import type { AnyMessageContent } from '@whiskeysockets/baileys';
 import type { Message } from '../types/message.js';
 import injectStickerExif from '../utils/StickerExif.js';
 
@@ -21,13 +21,11 @@ export default class ReplyDeserializer {
     return message;
   }
 
+  // Quoting belongs to ReplyConsumer: it holds the original WAMessage in flight,
+  // which Baileys requires to build the reply context. Here we only carry expiration.
   private static options(raw: ContentDict): Message['options'] | null {
-    const options: Record<string, unknown> = {};
-    if (raw.quoted_message_id) {
-      options.quoted = { key: { id: raw.quoted_message_id as string } } as WAMessage;
-    }
-    if (raw.expiration) options.ephemeralExpiration = raw.expiration;
-    return Object.keys(options).length > 0 ? (options as Message['options']) : null;
+    if (!raw.expiration) return null;
+    return { ephemeralExpiration: raw.expiration as number };
   }
 
   private static buffer(content: ContentDict): Buffer {

--- a/gateway/tests/unit/bridge/BrokerForwarder.test.ts
+++ b/gateway/tests/unit/bridge/BrokerForwarder.test.ts
@@ -40,14 +40,14 @@ describe('BrokerForwarder', () => {
     expect(commandData.text).toBe(',ping');
   });
 
-  it('tracks the correlation id against the jid', async () => {
+  it('tracks the correlation id against the jid and original message', async () => {
     const publisher = makePublisher('corr-42');
     const inFlight = new InFlightCommands();
     const data = GroupCommandData.build();
 
     await new BrokerForwarder(publisher, inFlight).forward(data, ',ping');
 
-    expect(inFlight.resolve('corr-42')).toBe(data.key.remoteJid);
+    expect(inFlight.resolve('corr-42')).toEqual({ jid: data.key.remoteJid, quoted: data });
   });
 
   it('stops typing and does not track when the publish fails', async () => {

--- a/gateway/tests/unit/bridge/InFlightCommands.test.ts
+++ b/gateway/tests/unit/bridge/InFlightCommands.test.ts
@@ -1,19 +1,22 @@
 import { describe, it, expect } from 'vitest';
+import type { WAMessage } from '@whiskeysockets/baileys';
 
 import InFlightCommands from '../../../src/bridge/InFlightCommands.js';
 
+const original = { key: { id: 'ORIG', remoteJid: 'g@g.us' } } as WAMessage;
+
 describe('InFlightCommands', () => {
-  it('resolves a tracked id to its jid', () => {
+  it('resolves a tracked id to its jid and original message', () => {
     const inFlight = new InFlightCommands();
 
-    inFlight.track('corr-1', 'g@g.us');
+    inFlight.track('corr-1', 'g@g.us', original);
 
-    expect(inFlight.resolve('corr-1')).toBe('g@g.us');
+    expect(inFlight.resolve('corr-1')).toEqual({ jid: 'g@g.us', quoted: original });
   });
 
   it('resolves a tracked id only once', () => {
     const inFlight = new InFlightCommands();
-    inFlight.track('corr-1', 'g@g.us');
+    inFlight.track('corr-1', 'g@g.us', original);
 
     inFlight.resolve('corr-1');
 

--- a/gateway/tests/unit/bridge/ReplyConsumer.test.ts
+++ b/gateway/tests/unit/bridge/ReplyConsumer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { WAMessage } from '@whiskeysockets/baileys';
 
 import ReplyConsumer from '../../../src/bridge/ReplyConsumer.js';
 import InFlightCommands from '../../../src/bridge/InFlightCommands.js';
@@ -63,8 +64,10 @@ describe('ReplyConsumer', () => {
     expect(whatsapp.sendMessage).toHaveBeenCalledWith('g@g.us', { text: 'pong' }, {});
   });
 
-  it('attaches quoted and expiration options', async () => {
-    const { whatsapp, deliver } = await startConsumer();
+  it('quotes the original tracked message and attaches expiration', async () => {
+    const { whatsapp, inFlight, deliver } = await startConsumer();
+    const original = { key: { id: 'ORIG_1', remoteJid: 'g@g.us' } } as WAMessage;
+    inFlight.track('corr-1', 'g@g.us', original);
 
     await deliver({
       id: 'corr-1',
@@ -81,8 +84,21 @@ describe('ReplyConsumer', () => {
     expect(whatsapp.sendMessage).toHaveBeenCalledWith(
       'g@g.us',
       { text: 'pong' },
-      { quoted: { key: { id: 'ORIG_1' } }, ephemeralExpiration: 86400 },
+      { quoted: original, ephemeralExpiration: 86400 },
     );
+  });
+
+  it('skips the quote when the original message is no longer tracked', async () => {
+    const { whatsapp, deliver } = await startConsumer();
+
+    await deliver({
+      id: 'corr-1',
+      messages: [
+        { jid: 'g@g.us', content: { type: 'text', text: 'pong' }, quoted_message_id: 'ORIG_1' },
+      ],
+    });
+
+    expect(whatsapp.sendMessage).toHaveBeenCalledWith('g@g.us', { text: 'pong' }, {});
   });
 
   it('decodes a base64 buffer reply', async () => {
@@ -102,7 +118,7 @@ describe('ReplyConsumer', () => {
 
   it('stops the typing indicator for a tracked command', async () => {
     const { inFlight, deliver } = await startConsumer();
-    inFlight.track('corr-1', 'g@g.us');
+    inFlight.track('corr-1', 'g@g.us', { key: { id: 'ORIG_1' } } as WAMessage);
 
     await deliver({
       id: 'corr-1',
@@ -114,7 +130,7 @@ describe('ReplyConsumer', () => {
 
   it('stops typing on an empty terminal reply via the registry', async () => {
     const { whatsapp, inFlight, deliver } = await startConsumer();
-    inFlight.track('corr-1', 'g@g.us');
+    inFlight.track('corr-1', 'g@g.us', { key: { id: 'ORIG_1' } } as WAMessage);
 
     await deliver({ id: 'corr-1', messages: [] });
 

--- a/gateway/tests/unit/bridge/ReplyDeserializer.test.ts
+++ b/gateway/tests/unit/bridge/ReplyDeserializer.test.ts
@@ -110,14 +110,14 @@ describe('ReplyDeserializer', () => {
       expect(message.options).toBeUndefined();
     });
 
-    it('quoted and expiration', async () => {
+    it('expiration only; quoting is the consumer responsibility', async () => {
       const message = await ReplyDeserializer.toMessage({
         jid: 'g@g.us',
         content: { type: 'text', text: 'x' },
         quoted_message_id: 'ORIG',
         expiration: 60,
       });
-      expect(message.options).toEqual({ quoted: { key: { id: 'ORIG' } }, ephemeralExpiration: 60 });
+      expect(message.options).toEqual({ ephemeralExpiration: 60 });
     });
   });
 });

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ wheels = [
 
 [[package]]
 name = "resenhazord2-core"
-version = "1.8.2"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aio-pika" },


### PR DESCRIPTION
## Why

Found in local end-to-end testing of the broker migration (v2.0.0), before promoting #111 to `main`.

### Critical: every quoted reply was broken on Baileys rc10
The reply deserializer rebuilt the quoted context as `{ key: { id } }`. Baileys rc10 calls `normalizeMessageContent(quoted.message)` on send; with no `message` it throws `TypeError: undefined is not an object (evaluating 'quotedMsg[msgType]')`. Result: the bot reacted with the emoji but **no reply was ever delivered**.

Fix: keep the original `WAMessage` in flight (`InFlightCommands`) and let `ReplyConsumer` attach it as the quote. `ReplyDeserializer` no longer fabricates a quote — it only carries expiration.

### Local dev stack pointed at the wrong broker host
`docker-compose.yml` (all-in-one) inherited `RABBITMQ_URL=localhost` from `.env`; inside the containers that is not the broker. Now overridden to the `rabbitmq` service name, so the bot connects and all consumers attach.

### uv.lock
`cz bump` updated `pyproject.toml` to 2.0.0 but not the lockfile; synced.

## Testing
- Gateway: 177 unit tests green; `check:ts` (eslint + tsc + prettier) clean.
- Verified live in the all-in-one Docker stack: `,oi` and `,pokemon team show` now deliver quoted replies end-to-end (`commands → bot → replies → gateway → WhatsApp`).

## Out of scope (separate issue)
View-once media (`,pokemon team` without `show`) does not render. Root-caused to a WhatsApp limitation on view-once originated from linked/companion devices (server accepts but does not propagate) — **not** a broker regression (identical `BaileysAdapter.sendMessage` path as the old WebSocket code) and not fixable by the V1/V2 wrapper. To be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)