### PR TITLE
fix(tests): align MockBrokerPort signatures with the BrokerPort protocol

### DIFF
--- a/tests/fixtures/mock_broker.py
+++ b/tests/fixtures/mock_broker.py
@@ -5,12 +5,14 @@ class MockBrokerPort:
     def __init__(self) -> None:
         self.published: list[tuple[str, bytes]] = []
         self.declared: list[str] = []
+        self.retry_queues: list[tuple[str, int, str]] = []
+        self.connected_urls: list[str] = []
         self.rpc_calls: list[tuple[str, bytes]] = []
         self.rpc_response: bytes = b'{}'
         self._handlers: dict[str, MessageHandler] = {}
 
-    async def connect(self, _url: str) -> None:
-        return None
+    async def connect(self, url: str) -> None:
+        self.connected_urls.append(url)
 
     async def rpc_call(self, queue: str, body: bytes) -> bytes:
         self.rpc_calls.append((queue, body))
@@ -19,8 +21,9 @@ class MockBrokerPort:
     async def declare(self, queue: str) -> None:
         self.declared.append(queue)
 
-    async def declare_retry_queue(self, queue: str, _ttl_ms: int, _dead_letter_to: str) -> None:
+    async def declare_retry_queue(self, queue: str, ttl_ms: int, dead_letter_to: str) -> None:
         self.declared.append(queue)
+        self.retry_queues.append((queue, ttl_ms, dead_letter_to))
 
     async def publish(self, queue: str, body: bytes) -> None:
         self.published.append((queue, body))


### PR DESCRIPTION
## Why

`tests/fixtures/mock_broker.py` prefixed unused params with `_` (to silence Sonar S1172), which renamed them away from the `BrokerPort` protocol's `url` / `ttl_ms` / `dead_letter_to`. Protocol conformance is by parameter name (protocols allow keyword calls), so `MockBrokerPort` no longer structurally matched `BrokerPort`.

`zuban` (CI type check) did not catch it, but `basedpyright` does:

```
"MockBrokerPort" is incompatible with protocol "BrokerPort"
  Parameter name mismatch: "url" versus "_url"
  Parameter name mismatch: "ttl_ms" versus "_ttl_ms" ...
```

## Fix

Restore the protocol parameter names and **record** the args (`connected_urls`, `retry_queues`) instead of discarding them — so S1172 stays satisfied (params are used) and the mock conforms to the protocol again.

## Testing
- `uv run zuban check` — clean
- `uv run basedpyright tests/fixtures/mock_broker.py tests/unit/adapters/test_broker_whatsapp_client.py` — 0 errors
- `uv run pytest tests/unit/adapters/test_broker_whatsapp_client.py` — 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)