### PR TITLE
fix(compose): drop deprecated RABBITMQ_VM_MEMORY_HIGH_WATERMARK env

### DIFF
--- a/compose.edge.yml
+++ b/compose.edge.yml
@@ -47,8 +47,9 @@ services:
       - "5672:5672"
       - "127.0.0.1:15672:15672"
     mem_limit: 400m
-    environment:
-      RABBITMQ_VM_MEMORY_HIGH_WATERMARK: "0.6"
+    # No RABBITMQ_VM_MEMORY_HIGH_WATERMARK env: rabbitmq:3.13 rejects that deprecated
+    # variable and refuses to start. The default 0.4 relative watermark is also the
+    # safer choice on this 1 GB node (blocks publishers before the host OOMs).
     volumes:
       - rabbitmq-data:/var/lib/rabbitmq
     logging:


### PR DESCRIPTION
## Why

The v2.0.0 release pipeline's **deploy-edge** job failed. Root cause found while provisioning the brand-new edge VM: `rabbitmq:3.13-management` **rejects** the deprecated `RABBITMQ_VM_MEMORY_HIGH_WATERMARK` env var and refuses to boot:

```
error: RABBITMQ_VM_MEMORY_HIGH_WATERMARK is set but deprecated
error: deprecated environment variables detected
```

The broker crash-looped → unhealthy → the gateway's `depends_on` failed → deploy aborted. The local `docker-compose.yml` never set this var, so it only surfaced on the edge node.

## Fix

Remove the env var. RabbitMQ's default `0.4` relative high-watermark is also the safer choice on the 1 GB edge node (blocks publishers before the host OOMs). If a custom watermark is ever needed, it should be set via a mounted `rabbitmq.conf`, not the deprecated env.

## Hotfix (targets `main`)

Production deploy is broken, so this targets `main` per the hotfix flow. Already applied manually on the edge VM to unblock provisioning; this commit makes it permanent so the next `git pull` / deploy stays consistent.

> Note: full edge↔core broker connectivity also requires an Oracle VCN security-list ingress rule for TCP 5672 from the core node — tracked separately, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)