### PR TITLE
fix(gateway): ignore the bot's own messages to break the reply loop

### DIFF
--- a/gateway/src/handlers/CommandHandler.ts
+++ b/gateway/src/handlers/CommandHandler.ts
@@ -17,6 +17,10 @@ export default class CommandHandler {
   private static readonly TEXT_PREVIEW_LENGTH = 200;
 
   static async run(data: WAMessage): Promise<void> {
+    // Never act on our own outgoing messages. In a DM the bot's reply echoes back as
+    // an upsert, and since DMs auto-forward it would re-trigger the agent endlessly.
+    if (data.key.fromMe) return;
+
     const text = GetTextMessage.run(data);
     const command = CommandFactory.getInstance().getStrategy(text);
 

--- a/gateway/tests/unit/handlers/CommandHandler.test.ts
+++ b/gateway/tests/unit/handlers/CommandHandler.test.ts
@@ -44,5 +44,17 @@ describe('CommandHandler', () => {
 
       expect(forward).not.toHaveBeenCalled();
     });
+
+    it('ignores messages the bot itself sent, to avoid replying to its own replies', async () => {
+      const forward = vi.fn();
+      Resenhazord2.brokerForwarder = { forward } as never;
+
+      const ownMessage = createGroupMessage(',ping');
+      ownMessage.key.fromMe = true;
+
+      await CommandHandler.run(ownMessage);
+
+      expect(forward).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Why (production incident)

After the v2.0.0 broker deploy, the bot entered an **infinite reply loop** in a DM, repeatedly sending `🤖 IA indisponível...` (the agent's LLM-down fallback). Logs showed `agent_mention_detected` → `agent_executing` → `agent_provider_failed` firing dozens of times per second, each with a new correlation id.

## Root cause

`CommandHandler.run` never filters `key.fromMe`. In a DM, the bot's own outgoing reply echoes back as a `messages.upsert` (`fromMe=true`); `shouldForward` returns `true` for **every** DM, so the reply was forwarded to the broker, re-triggered the agent, and replied again — forever. Latent since before the migration (no `fromMe` filter ever existed in the gateway path); exposed now by the agent feature + LLM outage.

## Fix

Drop `fromMe` messages at the top of `CommandHandler.run`. The bot never acts on its own messages.

## Mitigation already applied

Stopped the core bot to halt the loop. This hotfix + a `commands` queue purge will be deployed before restarting it.

## Testing
- New unit test: a `fromMe` command is not forwarded. 4/4 green; `check:ts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)