### PR TITLE
fix(gateway): render view-once via Baileys rc13 + getMediaType patch

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add --no-cache git ca-certificates
 
 WORKDIR /app
 COPY package.json bun.lock ./
+COPY patches ./patches
 RUN bun install --frozen-lockfile
 
 FROM oven/bun:1.3.9-alpine

--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@sentry/bun": "^10.51.0",
         "@upstash/redis": "^1.37.0",
-        "@whiskeysockets/baileys": "^7.0.0-rc10",
+        "@whiskeysockets/baileys": "7.0.0-rc13",
         "amqplib": "^2.0.1",
         "axios": "^1.16.0",
         "axios-retry": "^4.5.0",
@@ -32,6 +32,9 @@
         "vitest": "^4.1.5",
       },
     },
+  },
+  "patchedDependencies": {
+    "@whiskeysockets/baileys@7.0.0-rc13": "patches/@whiskeysockets%2Fbaileys@7.0.0-rc13.patch",
   },
   "overrides": {
     "brace-expansion": "^5.0.5",
@@ -445,7 +448,7 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
 
-    "@whiskeysockets/baileys": ["@whiskeysockets/baileys@7.0.0-rc10", "", { "dependencies": { "@cacheable/node-cache": "^1.4.0", "@hapi/boom": "^9.1.3", "async-mutex": "^0.5.0", "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git", "lru-cache": "^11.1.0", "music-metadata": "^11.12.3", "p-queue": "^9.0.0", "pino": "^9.6", "protobufjs": "^7.5.6", "whatsapp-rust-bridge": "0.5.3", "ws": "^8.13.0" }, "peerDependencies": { "audio-decode": "^2.1.3", "jimp": "^1.6.1", "link-preview-js": "^3.0.0", "sharp": "*" }, "optionalPeers": ["audio-decode", "jimp", "link-preview-js"] }, "sha512-tVHZRIE06HlQajHcLEsCa+gnH5z+dAXPjwHsGXDNY9/Y0iqbymQzHLvh4tMH/pi/ea/D617qCQhNkDT2B0tufg=="],
+    "@whiskeysockets/baileys": ["@whiskeysockets/baileys@7.0.0-rc13", "", { "dependencies": { "@cacheable/node-cache": "^1.4.0", "@hapi/boom": "^9.1.3", "async-mutex": "^0.5.0", "libsignal": "^6.0.0", "lru-cache": "^11.1.0", "music-metadata": "^11.12.3", "p-queue": "^9.0.0", "pino": "^9.6", "protobufjs": "^7.5.6", "whatsapp-rust-bridge": "0.5.4", "ws": "^8.13.0" }, "peerDependencies": { "audio-decode": "^2.1.3", "jimp": "^1.6.1", "link-preview-js": "^3.0.0", "sharp": "*" }, "optionalPeers": ["audio-decode", "jimp", "link-preview-js"] }, "sha512-8JPc8gaaCRykkjW2jxLGQ7/RZGrc7awO7WU+QJocf58eSUI9jAdcuYLynzhAbyU4UWvJJsHImZ+5E/JaZj5ypA=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -773,7 +776,7 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
-    "libsignal": ["@whiskeysockets/libsignal-node@github:whiskeysockets/libsignal-node#1c30d7d", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "6.8.8" } }, "WhiskeySockets-libsignal-node-1c30d7d"],
+    "libsignal": ["libsignal@6.0.0", "", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "^7.5.5" } }, "sha512-d/5V3YFtDljbFMufz4ncyUYGYhJl+vzAe+c2EFFBQ6bz1h8Q3IOMEGXYMzlibU60I+e8GagMMpji18iez3P1hA=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
@@ -1047,7 +1050,7 @@
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
-    "whatsapp-rust-bridge": ["whatsapp-rust-bridge@0.5.3", "", {}, "sha512-Xb3GAgtWQQJ30oI4a4pjM4+YUeli9CMLTwTIewUrb+AJMFElIkiT5uo+j1Zhc+amiV0Jj+LfX76c/EEZirJbGA=="],
+    "whatsapp-rust-bridge": ["whatsapp-rust-bridge@0.5.4", "", {}, "sha512-yYO1qSs0Fe7tGtnxOFHomocUD6IZtoAgmA4oDFyGIRZ67D3QZk3w7swA6XXFXNQngiyrg2k7tul6IrM3eUFh7A=="],
 
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@sentry/bun": "^10.51.0",
     "@upstash/redis": "^1.37.0",
-    "@whiskeysockets/baileys": "^7.0.0-rc10",
+    "@whiskeysockets/baileys": "7.0.0-rc13",
     "amqplib": "^2.0.1",
     "axios": "^1.16.0",
     "axios-retry": "^4.5.0",
@@ -65,5 +65,8 @@
     "postcss": "^8.5.10",
     "uuid": "^14.0.0",
     "vite": "^7.3.2"
+  },
+  "patchedDependencies": {
+    "@whiskeysockets/baileys@7.0.0-rc13": "patches/@whiskeysockets%2Fbaileys@7.0.0-rc13.patch"
   }
 }

--- a/gateway/patches/@whiskeysockets%2Fbaileys@7.0.0-rc13.patch
+++ b/gateway/patches/@whiskeysockets%2Fbaileys@7.0.0-rc13.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/Socket/messages-send.js b/lib/Socket/messages-send.js
+index d61e064d01252fb1aaae4bf7b0f295df8a3c4def..aa2523c92b6770732f969f31b64decbd01a14582 100644
+--- a/lib/Socket/messages-send.js
++++ b/lib/Socket/messages-send.js
+@@ -904,6 +904,10 @@ export const makeMessagesSocket = (config) => {
+         return 'text';
+     };
+     const getMediaType = (message) => {
++        const inner = message.viewOnceMessage?.message || message.viewOnceMessageV2?.message || message.viewOnceMessageV2Extension?.message;
++        if (inner) {
++            return getMediaType(inner);
++        }
+         if (message.imageMessage) {
+             return 'image';
+         }

--- a/gateway/tests/unit/infra/BaileysViewOncePatch.test.ts
+++ b/gateway/tests/unit/infra/BaileysViewOncePatch.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+// Guards the bun patch for WhiskeySockets/Baileys#2435. Baileys' internal getMediaType
+// checks message.imageMessage directly; a view-once message is wrapped in viewOnceMessage,
+// so without the patch it returns '' — the enc node ships an empty mediatype and WhatsApp
+// drops the media. getMediaType is not exported, so we assert the patch is present in the
+// installed source. Re-verify this when bumping @whiskeysockets/baileys.
+describe('Baileys view-once patch (getMediaType)', () => {
+  function patchedGetMediaTypeSource(): string {
+    const require = createRequire(import.meta.url);
+    const source = readFileSync(
+      require.resolve('@whiskeysockets/baileys/lib/Socket/messages-send.js'),
+      'utf8',
+    );
+    const start = source.indexOf('const getMediaType = (message) => {');
+    expect(start).toBeGreaterThan(-1);
+    return source.slice(start, start + 600);
+  }
+
+  it('unwraps the viewOnceMessage wrapper inside getMediaType', () => {
+    const region = patchedGetMediaTypeSource();
+
+    expect(region).toContain('viewOnceMessage?.message');
+    expect(region).toContain('viewOnceMessageV2?.message');
+  });
+
+  it('unwraps before the plain imageMessage lookup, so it takes effect', () => {
+    const region = patchedGetMediaTypeSource();
+
+    expect(region.indexOf('viewOnceMessage?.message')).toBeLessThan(
+      region.indexOf('message.imageMessage'),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

View-once media (e.g. `,pokemon team` without `show`) sent from the bot never rendered on WhatsApp — the message was accepted (media uploaded, server returned a key) but appeared as nothing. It worked on Baileys rc.9 and broke after the rc10 upgrade.

## Root cause (data-driven)

Confirmed against upstream **[WhiskeySockets/Baileys#2435](https://github.com/WhiskeySockets/Baileys/pull/2435)**. The relay's `getMediaType()` checks `message.imageMessage` directly, but a view-once message is wrapped in `viewOnceMessage`, so it returned `''`. The `enc` node then went out with an empty `mediatype` attribute and WhatsApp dropped the media.

Investigation ruled out (with live experiments): the `messageContextInfo` reporting token (injected it on rc.9 → still rendered), `getMediaType`/`prepareWAMessageMedia` proto output (identical), and the V1↔V2 wrapper. The only real difference was at the wire/enc-node level — exactly what #2435 fixes.

## Fix

- Bump `@whiskeysockets/baileys` rc10 → **rc13** (connection-deadlock + ghost-session fixes from rc10–rc13).
- Apply the upstream `getMediaType` fix via **`bun patch`** (unwrap `viewOnceMessage` before detecting the media type). Drop the patch once #2435 ships in a release.
- `Dockerfile`: `COPY patches ./patches` before the frozen install so the patch applies in the image.

## Testing

- Verified live end-to-end in the local Docker stack: `,pokemon team` now renders as a view-once photo on rc13 + patch.
- `check:ts` clean; 178 gateway tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)